### PR TITLE
Bess changes/fixes

### DIFF
--- a/TiTSFD.as3proj
+++ b/TiTSFD.as3proj
@@ -56,6 +56,7 @@
     <element path="style_uiscroll.swc" />
     <element path="lib\AndroidFullScreen.ane" />
     <element path="lib\adt\AndroidFullScreen.ane" />
+    <element path="D:\Spiele\Trails in Tainted Space\libraries\flash.swc" />
   </libraryPaths>
   <!-- External Libraries -->
   <externalLibraryPaths>

--- a/TiTSFD.as3proj
+++ b/TiTSFD.as3proj
@@ -56,7 +56,6 @@
     <element path="style_uiscroll.swc" />
     <element path="lib\AndroidFullScreen.ane" />
     <element path="lib\adt\AndroidFullScreen.ane" />
-    <element path="D:\Spiele\Trails in Tainted Space\libraries\flash.swc" />
   </libraryPaths>
   <!-- External Libraries -->
   <externalLibraryPaths>

--- a/includes/tarkus/bess.as
+++ b/includes/tarkus/bess.as
@@ -1366,7 +1366,7 @@ public function bessFollowerMenu():void
 
 	if (flags["BESS_EVENT_24"] == undefined)
 	{
-		addDisabledButton(5, "Date");
+		addDisabledButton(5,"Locked","Locked","You don’t know her well enough for this.");
 	}
 	else
 	{
@@ -1382,7 +1382,7 @@ public function bessFollowerMenu():void
 		}
 		else
 		{
-			addDisabledButton(5, "Date");
+			addDisabledButton(5, "Date","Locked","It doens't look like [bess.name] wants to go on a date again anytime soon.");
 		}
 	}
 
@@ -2665,14 +2665,14 @@ public function talkToBessAboutHips():void
 	if (bess.hipRatingRaw == 2) addDisabledButton(1, "Slender");
 	else addButton(1, "Slender", setBessHipSize, 2);
 	if (bess.hipRatingRaw == 4) addDisabledButton(2, "Average");
-	else addButton(2, "Average", setBessHipSize, 5);
+	else addButton(2, "Average", setBessHipSize, 4);
 	if (bess.hipRatingRaw == 6) addDisabledButton(3, "Ample");
-	else addButton(3, "Ample", setBessHipSize, 8);
+	else addButton(3, "Ample", setBessHipSize, 6);
 	if (bess.hipRatingRaw == 10) addDisabledButton(4, "Curvy");
-	else addButton(4, "Voluptuous", setBessHipSize, 16);
-	if (bess.hipRatingRaw == 15) addDisabledButton(4, "Voluptuous");
-	else addButton(5, "Voluptuous", setBessHipSize, 16);
-	if (bess.hipRatingRaw == 20) addDisabledButton(5, "Massive");
+	else addButton(4, "Curvy", setBessHipSize, 10);
+	if (bess.hipRatingRaw == 15) addDisabledButton(5, "Voluptuous");
+	else addButton(5, "Voluptuous", setBessHipSize, 15);
+	if (bess.hipRatingRaw == 20) addDisabledButton(6, "Massive");
 	else addButton(6, "Massive", setBessHipSize, 20);
 
 	addButton(14, "Back", talkToBessAboutBodyShape);
@@ -2696,18 +2696,18 @@ public function talkToBessAboutButt():void
 	if (bess.buttRatingRaw == 2) addDisabledButton(1, "Tight");
 	else addButton(1, "Tight", setBessButtSize, 2);
 	if (bess.buttRatingRaw == 4) addDisabledButton(2, "Average");
-	else addButton(2, "Average", setBessButtSize, 5);
+	else addButton(2, "Average", setBessButtSize, 4);
 	if (bess.buttRatingRaw == 6) addDisabledButton(3, "Noticable");
-	else addButton(3, "Noticable", setBessButtSize, 8);
+	else addButton(3, "Noticable", setBessButtSize, 6);
 	if (bess.buttRatingRaw == 8) addDisabledButton(4, "Large");
-	else addButton(4, "Large", setBessButtSize, 16);
+	else addButton(4, "Large", setBessButtSize, 8);
 	if (bess.buttRatingRaw == 10) addDisabledButton(5, "Jiggly");
-	else addButton(5, "Jiggly", setBessButtSize, 20);
-	if (bess.buttRatingRaw == 13) addDisabledButton(5, "Expansive");
-	else addButton(6, "Expansive", setBessButtSize, 20);
-	if (bess.buttRatingRaw == 16) addDisabledButton(5, "Huge");
-	else addButton(7, "Huge", setBessButtSize, 20);
-	if (bess.buttRatingRaw == 20) addDisabledButton(5, "Massive");
+	else addButton(5, "Jiggly", setBessButtSize, 10);
+	if (bess.buttRatingRaw == 13) addDisabledButton(6, "Expansive");
+	else addButton(6, "Expansive", setBessButtSize, 13);
+	if (bess.buttRatingRaw == 16) addDisabledButton(7, "Huge");
+	else addButton(7, "Huge", setBessButtSize, 16);
+	if (bess.buttRatingRaw == 20) addDisabledButton(8, "Massive");
 	else addButton(8, "Massive", setBessButtSize, 20);
 
 	addButton(14, "Back", talkToBessAboutBodyShape);

--- a/includes/tarkus/bess.as
+++ b/includes/tarkus/bess.as
@@ -194,21 +194,25 @@ public function bessNippleType():String
 
 public function bessAssSize():String
 {
-	if (bess.buttRatingRaw <= 0) return "boyish";
-	if (bess.buttRatingRaw <= 2) return "slender";
-	if (bess.buttRatingRaw <= 5) return "average";
-	if (bess.buttRatingRaw <= 8) return "ample";
-	if (bess.buttRatingRaw <= 16) return "voluptuous";
+	if (bess.buttRatingRaw <= 0) return "buttless";
+	if (bess.buttRatingRaw <= 2) return "tight";
+	if (bess.buttRatingRaw <= 4) return "average";
+	if (bess.buttRatingRaw <= 6) return "noticable";
+	if (bess.buttRatingRaw <= 8) return "large";
+	if (bess.buttRatingRaw <= 10) return "jiggly";
+	if (bess.buttRatingRaw <= 13) return "expansive";
+	if (bess.buttRatingRaw <= 16) return "huge";
 	return "massive";
 }
 
 public function bessThighSize():String
 {
-	if (bess.hipRatingRaw <= 0) return "boyish";
+	if (bess.hipRatingRaw == 0) return "boyish";
 	if (bess.hipRatingRaw <= 2) return "slender";
-	if (bess.hipRatingRaw <= 5) return "average";
-	if (bess.hipRatingRaw <= 8) return "ample";
-	if (bess.hipRatingRaw <= 16) return "voluptuous";
+	if (bess.hipRatingRaw <= 4) return "average";
+	if (bess.hipRatingRaw <= 6) return "ample";
+	if (bess.hipRatingRaw <= 10) return "curvy";
+	if (bess.hipRatingRaw <= 15) return "voluptuous";
 	return "massive";
 }
 
@@ -2655,14 +2659,16 @@ public function talkToBessAboutHips():void
 	else addButton(0, "Boyish", setBessHipSize, 0);
 	if (bess.hipRatingRaw == 2) addDisabledButton(1, "Slender");
 	else addButton(1, "Slender", setBessHipSize, 2);
-	if (bess.hipRatingRaw == 5) addDisabledButton(2, "Average");
+	if (bess.hipRatingRaw == 4) addDisabledButton(2, "Average");
 	else addButton(2, "Average", setBessHipSize, 5);
-	if (bess.hipRatingRaw == 8) addDisabledButton(3, "Ample");
+	if (bess.hipRatingRaw == 6) addDisabledButton(3, "Ample");
 	else addButton(3, "Ample", setBessHipSize, 8);
-	if (bess.hipRatingRaw == 16) addDisabledButton(4, "Voluptuous");
+	if (bess.hipRatingRaw == 10) addDisabledButton(4, "Curvy");
 	else addButton(4, "Voluptuous", setBessHipSize, 16);
+	if (bess.hipRatingRaw == 15) addDisabledButton(4, "Voluptuous");
+	else addButton(5, "Voluptuous", setBessHipSize, 16);
 	if (bess.hipRatingRaw == 20) addDisabledButton(5, "Massive");
-	else addButton(5, "Massive", setBessHipSize, 20);
+	else addButton(6, "Massive", setBessHipSize, 20);
 
 	addButton(14, "Back", talkToBessAboutBodyShape);
 }
@@ -2680,18 +2686,24 @@ public function talkToBessAboutButt():void
 	output("<i>“My ass, huh? Were you thinking of putting some junk in this trunk, or taking some out, "+ bessPCName() +"?”</i>");
 
 	clearMenu();
-	if (bess.buttRatingRaw == 0) addDisabledButton(0, "Boyish");
-	else addButton(0, "Boyish", setBessButtSize, 0);
-	if (bess.buttRatingRaw == 2) addDisabledButton(1, "Slender");
-	else addButton(1, "Slender", setBessButtSize, 2);
-	if (bess.buttRatingRaw == 5) addDisabledButton(2, "Average");
+	if (bess.buttRatingRaw == 0) addDisabledButton(0, "Buttless");
+	else addButton(0, "Buttless", setBessButtSize, 0);
+	if (bess.buttRatingRaw == 2) addDisabledButton(1, "Tight");
+	else addButton(1, "Tight", setBessButtSize, 2);
+	if (bess.buttRatingRaw == 4) addDisabledButton(2, "Average");
 	else addButton(2, "Average", setBessButtSize, 5);
-	if (bess.buttRatingRaw == 8) addDisabledButton(3, "Ample");
-	else addButton(3, "Ample", setBessButtSize, 8);
-	if (bess.buttRatingRaw == 16) addDisabledButton(4, "Voluptuous");
-	else addButton(4, "Voluptuous", setBessButtSize, 16);
+	if (bess.buttRatingRaw == 6) addDisabledButton(3, "Noticable");
+	else addButton(3, "Noticable", setBessButtSize, 8);
+	if (bess.buttRatingRaw == 8) addDisabledButton(4, "Large");
+	else addButton(4, "Large", setBessButtSize, 16);
+	if (bess.buttRatingRaw == 10) addDisabledButton(5, "Jiggly");
+	else addButton(5, "Jiggly", setBessButtSize, 20);
+	if (bess.buttRatingRaw == 13) addDisabledButton(5, "Expansive");
+	else addButton(6, "Expansive", setBessButtSize, 20);
+	if (bess.buttRatingRaw == 16) addDisabledButton(5, "Huge");
+	else addButton(7, "Huge", setBessButtSize, 20);
 	if (bess.buttRatingRaw == 20) addDisabledButton(5, "Massive");
-	else addButton(5, "Massive", setBessButtSize, 20);
+	else addButton(8, "Massive", setBessButtSize, 20);
 
 	addButton(14, "Back", talkToBessAboutBodyShape);
 }

--- a/includes/tarkus/bess.as
+++ b/includes/tarkus/bess.as
@@ -1365,12 +1365,12 @@ public function bessFollowerMenu():void
 	}
 	else
 	{
-		addDisabledButton(4,"Locked","Locked","You don’t know her well enough for this.");
+		addDisabledButton(4,"Locked","Locked","You don’t know [bess.himHer] well enough for this.");
 	}
 
 	if (flags["BESS_EVENT_24"] == undefined)
 	{
-		addDisabledButton(5,"Locked","Locked","You don’t know her well enough for this.");
+		addDisabledButton(5,"Locked","Locked","You don’t know [bess.himHer] well enough for this.");
 	}
 	else
 	{

--- a/includes/tarkus/bess.as
+++ b/includes/tarkus/bess.as
@@ -207,7 +207,7 @@ public function bessAssSize():String
 
 public function bessThighSize():String
 {
-	if (bess.hipRatingRaw == 0) return "boyish";
+	if (bess.hipRatingRaw <= 0) return "boyish";
 	if (bess.hipRatingRaw <= 2) return "slender";
 	if (bess.hipRatingRaw <= 4) return "average";
 	if (bess.hipRatingRaw <= 6) return "ample";
@@ -1371,7 +1371,6 @@ public function bessFollowerMenu():void
 	if (flags["BESS_EVENT_24"] == undefined)
 	{
 		addDisabledButton(5,"Locked","Locked","You don’t know her well enough for this.");
-		
 	}
 	else
 	{
@@ -1539,7 +1538,7 @@ public function bessFunctions():void
 
 	bessFunctionsMenu();
 }
-
+//used when returning from customizing something, keeps the previous text onscreen
 public function bessFunctionsMenu():void
 {
 	clearMenu();

--- a/includes/tarkus/bess.as
+++ b/includes/tarkus/bess.as
@@ -1495,8 +1495,7 @@ public function bessAppearance():void
 }
 
 //Functions
-
-public function bessFunctionsMenu():void
+public function bessFunctions():void
 {
 	clearOutput();
 	bessHeader();
@@ -1533,6 +1532,11 @@ public function bessFunctionsMenu():void
 		output("\n\n<i>“Of course, "+ bessPCName() +"! What would you like me to change?”</i> [bess.name]’s [bess.eyeColor] eyes are " + bess.mf("shining brightly","positively glittering") + ", waiting to hear what you want to switch up.");
 	}
 
+	bessFunctionsMenu();
+}
+
+public function bessFunctionsMenu():void
+{
 	clearMenu();
 	addButton(0, "Titles", talkToBessAboutTitles, undefined, "Titles", "Change [bess.name]’s name or what you call each other in sexual and non-sexual encounters.");
 
@@ -1554,6 +1558,7 @@ public function bessFunctionsMenu():void
 	addButton(14, "Back", bessFollowerMenu);
 }
 
+
 //Titles
 public function talkToBessAboutTitles():void
 {
@@ -1569,7 +1574,7 @@ public function talkToBessAboutTitles():void
 	addButton(3, "YourSexName", bessTitlesYourSexName, undefined, "Your Sex Name", "The name that [bess.name] will call you in sexual encounters.");
 	addButton(4, bess.mf("His", "Her") + "SexName", bessTitlesTheirSexName, undefined, bess.mf("His", "Her") + " Sex Name", "The title that you will call [bess.name] in sexual encounters.");
 
-	addButton(14, "Back", bessFunctionsMenu);
+	addButton(14, "Back", bessFunctions);
 }
 
 public function bessTitlesTheirName():void
@@ -1638,7 +1643,7 @@ public function bessTitlesAcceptRename():void
 	output("<i>“Very well, from now on I shall be known as [bess.name]!”</i>");
 
 	clearMenu();
-	addButton(0, "Next", bessFunctionsMenu);
+	addButton(0, "Next", bessFunctions);
 }
 
 public function bessTitlesYourTitles():void
@@ -1781,7 +1786,7 @@ public function bessTitleList(tarPC:Boolean, sex:Boolean):void
 	{
 		if (i > 0 && (i + 1) % 15 == 0)
 		{
-			addButton(i, "Back", bessFunctionsMenu);
+			addButton(i, "Back", talkToBessAboutTitles);
 			continue;
 		}
 		else
@@ -1841,7 +1846,7 @@ public function bessSetTitleOption(opts:Array):void
 	if (!tarPC &&  sex) flags["BESS_SEX_NAME"] = newTitle;
 
 	clearMenu();
-	addButton(0, "Next", bessFunctionsMenu);
+	addButton(0, "Next", bessFunctions);
 }
 
 public function talkToBessAboutRoles():void
@@ -1868,7 +1873,7 @@ public function talkToBessAboutRoles():void
 	else if (sRole == 1) output(" the role of a dominant partner.)")
 	else if (sRole == 2) output(" the role of a submissive partner.)");
 	
-	addButton(14, "Back", bessFunctionsMenu);
+	addButton(14, "Back", bessFunctions);
 }
 
 public function setBessRole(newRole:int):void
@@ -1905,7 +1910,7 @@ public function talkToBessAboutHair():void
 	if (bess.hairLength > 0) addButton(2, "Style", talkToBessAboutHairStyle);
 	else addDisabledButton(2, "Style", "Hair Style", "[bess.name] has to have hair to be able to select its style!");
 
-	addButton(14, "Back", bessFunctionsMenu);
+	addButton(14, "Back", bessFunctions);
 }
 
 public function talkToBessAboutHairColor():void
@@ -2041,7 +2046,7 @@ public function bessSetHairLength(newLength:int):void
 	output("!</b>");
 
 	clearMenu();
-	addButton(0, "Next", bessFunctionsMenu);
+	addButton(0, "Next", bessFunctions);
 }
 
 public function talkToBessAboutHairStyle():void
@@ -2131,7 +2136,7 @@ public function talkToBessAboutEyes():void
 	{
 		if (i > 0 && (i + 1) % 15 == 0)
 		{
-			addButton(i, "Back", bessFunctionsMenu);
+			addButton(i, "Back", bessFunctions);
 			continue;
 		}
 		else
@@ -2151,7 +2156,7 @@ public function talkToBessAboutEyes():void
 
 	if (options.length < 15)
 	{
-		addButton(14, "Back", bessFunctionsMenu);
+		addButton(14, "Back", bessFunctions);
 	}
 }
 
@@ -2195,7 +2200,7 @@ public function talkToBessAboutBoobs():void
 	if (flags["BESS_BOOBCHANGED"] == undefined) addDisabledButton(2, "Nipples");
 	else addButton(2, "Nipples", talkToBessAboutNipples);
 	
-	addButton(14, "Back", bessFunctionsMenu);
+	addButton(14, "Back", bessFunctions);
 }
 
 public function talkToBessAboutBoobSize():void
@@ -2217,7 +2222,7 @@ public function talkToBessAboutBoobSize():void
 	{
 		if (i > 0 && (i + 1) % 15 == 0)
 		{
-			addButton(i, "Back", bessFunctionsMenu);
+			addButton(i, "Back", bessFunctions);
 			continue;
 		}
 		else
@@ -2644,7 +2649,7 @@ public function talkToBessAboutBodyShape():void
 	addButton(3, "Stomach", talkToBessAboutStomach);
 	addButton(4, "Thickness", talkToBessAboutThickness);
 
-	addButton(14, "Back", bessFunctionsMenu);
+	addButton(14, "Back", bessFunctions);
 }
 
 public function talkToBessAboutHips():void
@@ -2978,7 +2983,7 @@ public function talkToBessAboutGenitals():void
 	if (bess.hasCock()) addButton(2, "Knot", talkToBessAboutKnot, undefined, "Cock Knot", "Whenever [bess.name] penetrates you with [bess.hisHer] cock, it will swell and lock inside until [bess.heShe] has finished cumming inside.");
 	else addDisabledButton(2, "Knot", "Knot State", "[bess.name] needs to be sporting a cock to configure its knottyness!");
 
-	addButton(14, "Back", bessFunctionsMenu);
+	addButton(14, "Back", bessFunctions);
 }
 
 public function talkToBessAboutCock():void
@@ -3411,7 +3416,7 @@ public function talkToBessAboutCum():void
 	if (bess.hasVagina()) addButton(1, "GirlCum F", talkToBessAboutCumFlavour, false, "Girl Cum Flavor", "Change [bess.hisHer] girl cum flavor.");
 	else addDisabledButton(1, "GirlCum F");
 
-	addButton(14, "Back", bessFunctionsMenu);
+	addButton(14, "Back", bessFunctions);
 }
 
 public function talkToBessAboutCumFlavour(asCock:Boolean):void
@@ -3435,7 +3440,7 @@ public function talkToBessAboutCumFlavour(asCock:Boolean):void
 	{
 		if (i > 0 && (i + 1) % 15 == 0)
 		{
-			addButton(i, "Back", bessFunctionsMenu);
+			addButton(i, "Back", talkToBessAboutCum);
 			continue;
 		}
 		else
@@ -3458,7 +3463,7 @@ public function talkToBessAboutCumFlavour(asCock:Boolean):void
 	
 	if (opts.length < 15)
 	{
-		addButton(14, "Back", talkToBessAboutGenitals);
+		addButton(14, "Back", talkToBessAboutCum);
 	}
 }
 
@@ -3521,7 +3526,7 @@ public function talkToBessAboutClothes():void
 	addButton(6, "Wings", talkToBessAboutWings, undefined, "Wings", "Change [bess.hisHer] wings.");
 	addButton(7, "Items", talkToBessAboutItems, undefined, "Items", "Change [bess.hisHer] accessories.");
 
-	addButton(14, "Back", bessFunctionsMenu);
+	addButton(14, "Back", bessFunctions);
 }
 
 // this is only really used to handle nudity

--- a/includes/tarkus/bess.as
+++ b/includes/tarkus/bess.as
@@ -2664,7 +2664,7 @@ public function talkToBessAboutHips():void
 	if (bess.hipRatingRaw == 20) addDisabledButton(5, "Massive");
 	else addButton(5, "Massive", setBessHipSize, 20);
 
-	addButton(14, "Back", bessFunctionsMenu);
+	addButton(14, "Back", talkToBessAboutBodyShape);
 }
 
 public function setBessHipSize(newRating:int):void
@@ -2693,7 +2693,7 @@ public function talkToBessAboutButt():void
 	if (bess.buttRatingRaw == 20) addDisabledButton(5, "Massive");
 	else addButton(5, "Massive", setBessButtSize, 20);
 
-	addButton(14, "Back", bessFunctionsMenu);
+	addButton(14, "Back", talkToBessAboutBodyShape);
 }
 
 public function setBessButtSize(newRating:int):void
@@ -2720,7 +2720,7 @@ public function talkToBessAboutTone():void
 	if (bess.tone == 0) addDisabledButton(4, "Soft");
 	else addButton(4, "Soft", setBessTone, 0);
 	
-	addButton(14, "Back", bessFunctionsMenu);
+	addButton(14, "Back", talkToBessAboutBodyShape);
 }
 
 public function setBessTone(newTone:int):void
@@ -2747,7 +2747,7 @@ public function talkToBessAboutThickness():void
 	if (bess.thickness == 0) addDisabledButton(4, "Thin");
 	else addButton(4, "Thin", setBessThickness, 0);
 	
-	addButton(14, "Back", bessFunctionsMenu);
+	addButton(14, "Back", talkToBessAboutBodyShape);
 }
 
 public function setBessThickness(newThickness:int):void
@@ -2821,7 +2821,7 @@ public function talkToBessAboutStomach():void
 	if (bess.bellyRatingRaw == 100) addDisabledButton(10, "StupidlyHuge");
 	else addButton(10, "StupidlyHuge", setBessBelly, 100);
 	
-	addButton(14, "Back", bessFunctionsMenu);
+	addButton(14, "Back", talkToBessAboutBodyShape);
 }
 
 public function setBessBelly(newRating:int):void
@@ -3026,7 +3026,7 @@ public function talkToBessAboutCock():void
 	else if (bessHasCockType(BESS_COCKTYPE_VENUSPITCHER)) addButton(12, "Plant", setBessCockType, GLOBAL.TYPE_VENUSPITCHER);
 	else addDisabledButton(12, "Plant", "Plant", "[bess.name] doesn’t have access to this cock style!");
 
-	addButton(14, "Back", bessFunctionsMenu);
+	addButton(14, "Back", talkToBessAboutGenitals);
 }
 
 public function setBessCockType(newType:int):void
@@ -3295,7 +3295,7 @@ public function talkToBessAboutPussy():void
 	if (bess.hasVagina()) addButton(1, "LosePussy", bessRemovePussy);
 	else addDisabledButton(1, "LosePussy");
 
-	addButton(14, "Back", bessFunctionsMenu);
+	addButton(14, "Back", talkToBessAboutGenitals);
 }
 
 public function bessRemovePussy():void
@@ -3351,7 +3351,7 @@ public function talkToBessAboutKnot():void
 		addButton(1, "LoseKnot", bessRemoveKnot);
 	}
 
-	addButton(14, "Back", bessFunctionsMenu);
+	addButton(14, "Back", talkToBessAboutGenitals);
 }
 
 public function bessGainKnot():void
@@ -3446,7 +3446,7 @@ public function talkToBessAboutCumFlavour(asCock:Boolean):void
 	
 	if (opts.length < 15)
 	{
-		addButton(14, "Back", bessFunctionsMenu);
+		addButton(14, "Back", talkToBessAboutGenitals);
 	}
 }
 

--- a/includes/tarkus/bess.as
+++ b/includes/tarkus/bess.as
@@ -1861,8 +1861,8 @@ public function talkToBessAboutRoles():void
 
 	//[Equal] [Dominant] [Submissive]
 	clearMenu();
-	if (flags["BESS_SEX_ROLE"] == 0) addDisabledButton(0, "Equals"); 
-	else addButton(0, "Equals", setBessRole, 0);
+	if (flags["BESS_SEX_ROLE"] == 0) addDisabledButton(0, "Equal"); 
+	else addButton(0, "Equal", setBessRole, 0);
 	if (flags["BESS_SEX_ROLE"] == 1) addDisabledButton(1, "Dominant");
 	else addButton(1, "Dominant", setBessRole, 1);
 	if (flags["BESS_SEX_ROLE"] == 2) addDisabledButton(2, "Submissive");
@@ -2650,7 +2650,7 @@ public function talkToBessAboutBodyShape():void
 	clearOutput();
 	bessHeader();
 
-	output("<i>“My body shape is easily changed. What would you like me to alter...?</i>");
+	output("<i>“My body shape is easily changed. What would you like me to alter...?”</i>");
 
 	clearMenu();
 	addButton(0, "Hips", talkToBessAboutHips);
@@ -3498,7 +3498,7 @@ public function bessSetCumFlavor(opts:Array):void
 	{
 		bess.girlCumType = flav;
 		if (flav != GLOBAL.FLUID_TYPE_GIRLCUM) output("of " + bessGirlCumFlavor());
-		else output(" like regular girlcum");
+		else output("like regular girlcum");
 	}
 	output("!</i> [bess.name] cheerfully exclaims.");
 	
@@ -4313,7 +4313,7 @@ public function talkToBessAboutThings():void
 
 	clearMenu();
 	addButton(0, "SpendTime", bessSpendTime);
-	addButton(1, bessName(), talkToBessAboutBess);
+	addButton(1, StringUtil.toTitleCase(bessName()), talkToBessAboutBess);
 	addButton(2, "You", talkToBessAboutPC);
 	
 	if (flags["BESS_EVENT_28"] == undefined) addButton(3, "JoyCo", talkToBessAboutJoyco);

--- a/includes/tarkus/bess.as
+++ b/includes/tarkus/bess.as
@@ -1363,15 +1363,10 @@ public function bessFollowerMenu():void
 	{
 		addButton(4, "Int. Sex", bessIntimateSexMenu);
 	}
-	else
-	{
-		addDisabledButton(4,"Locked","Locked","You don’t know her well enough for this.");
-	}
 
 	if (flags["BESS_EVENT_24"] == undefined)
 	{
 		addDisabledButton(5,"Locked","Locked","You don’t know her well enough for this.");
-		
 	}
 	else
 	{
@@ -1387,7 +1382,7 @@ public function bessFollowerMenu():void
 		}
 		else
 		{
-			addDisabledButton(5, "Date","Locked","It doens't seem like [bess.name] wants to go on a date ever again after the hassle on Ekurana.");
+			addDisabledButton(5, "Date","Locked","It doens't look like [bess.name] wants to go on a date again anytime soon.");
 		}
 	}
 
@@ -2091,15 +2086,8 @@ public function talkToBessAboutHairStyle():void
 		{
 			optSlot++;
 		}
-		// bessSetHairStyle() adds an article to some of the styles, so lets check both possibilities
-		if (options[optSlot] == bessHairStyle() || indefiniteArticle(options[optSlot]) == bessHairStyle())
-		{
-			addDisabledButton(i, StringUtil.toTitleCase(options[optSlot]));
-		}
-		else
-		{
-			addButton(i, StringUtil.toTitleCase(options[optSlot]), bessSetHairStyle, options[optSlot]);
-		}
+
+		addButton(i, StringUtil.toTitleCase(options[optSlot]), bessSetHairStyle, options[optSlot]);
 	}
 }
 

--- a/includes/tarkus/bess.as
+++ b/includes/tarkus/bess.as
@@ -1339,7 +1339,7 @@ public function bessFollowerMenu():void
 	clearMenu();
 	
 	addButton(0, "Discuss", talkToBessAboutThings);
-	addButton(1, "Functions", bessFunctions, undefined, "Functions", "Go about setting [bess.name]’s various functions, from what [bess.heShe] calls you, [bess.hisHer] sexual roles, what [bess.heShe] wears, to [bess.hisHer] customizable body parts.");
+	addButton(1, "Functions", bessFunctionsMenu, undefined, "Functions", "Go about setting [bess.name]’s various functions, from what [bess.heShe] calls you, [bess.hisHer] sexual roles, what [bess.heShe] wears, to [bess.hisHer] customizable body parts.");
 	addButton(2, "Accessories", talkToBessAboutAccessories);
 	
 	if ((flags["BESS_FRIEND"] != undefined || flags["BESS_LOVER"] != undefined) && bessAffection() < 30)
@@ -1491,7 +1491,8 @@ public function bessAppearance():void
 }
 
 //Functions
-public function bessFunctions():void
+
+public function bessFunctionsMenu():void
 {
 	clearOutput();
 	bessHeader();
@@ -1528,11 +1529,6 @@ public function bessFunctions():void
 		output("\n\n<i>“Of course, "+ bessPCName() +"! What would you like me to change?”</i> [bess.name]’s [bess.eyeColor] eyes are " + bess.mf("shining brightly","positively glittering") + ", waiting to hear what you want to switch up.");
 	}
 
-	bessFunctionsMenu();
-}
-
-public function bessFunctionsMenu():void
-{
 	clearMenu();
 	addButton(0, "Titles", talkToBessAboutTitles, undefined, "Titles", "Change [bess.name]’s name or what you call each other in sexual and non-sexual encounters.");
 
@@ -1638,7 +1634,7 @@ public function bessTitlesAcceptRename():void
 	output("<i>“Very well, from now on I shall be known as [bess.name]!”</i>");
 
 	clearMenu();
-	addButton(0, "Next", bessFunctions);
+	addButton(0, "Next", bessFunctionsMenu);
 }
 
 public function bessTitlesYourTitles():void
@@ -1924,7 +1920,7 @@ public function talkToBessAboutHairColor():void
 	{
 		if (i > 0 && (i + 1) % 15 == 0)
 		{
-			addButton(i, "Back", bessFunctionsMenu);
+			addButton(i, "Back", talkToBessAboutHair);
 			continue;
 		}
 		else
@@ -1985,7 +1981,7 @@ public function talkToBessAboutHairLength():void
 		}
 	}
 
-	addButton(14, "Back", bessFunctionsMenu);
+	addButton(14, "Back", talkToBessAboutHair);
 }
 
 public function bessSetHairLength(newLength:int):void
@@ -2074,7 +2070,7 @@ public function talkToBessAboutHairStyle():void
 	{
 		if (i > 0 && (i + 1) % 15 == 0)
 		{
-			addButton(i, "Back", bessFunctionsMenu);
+			addButton(i, "Back", talkToBessAboutHair);
 			continue;
 		}
 		else

--- a/includes/tarkus/bess.as
+++ b/includes/tarkus/bess.as
@@ -1562,7 +1562,6 @@ public function bessFunctionsMenu():void
 	addButton(14, "Back", bessFollowerMenu);
 }
 
-
 //Titles
 public function talkToBessAboutTitles():void
 {

--- a/includes/tarkus/bess.as
+++ b/includes/tarkus/bess.as
@@ -2232,7 +2232,7 @@ public function talkToBessAboutBoobSize():void
 	{
 		if (i > 0 && (i + 1) % 15 == 0)
 		{
-			addButton(i, "Back", bessFunctions);
+			addButton(i, "Back", talkToBessAboutBoobs);
 			continue;
 		}
 		else

--- a/includes/tarkus/bess.as
+++ b/includes/tarkus/bess.as
@@ -1363,10 +1363,15 @@ public function bessFollowerMenu():void
 	{
 		addButton(4, "Int. Sex", bessIntimateSexMenu);
 	}
+	else
+	{
+		addDisabledButton(4,"Locked","Locked","You don’t know her well enough for this.");
+	}
 
 	if (flags["BESS_EVENT_24"] == undefined)
 	{
 		addDisabledButton(5,"Locked","Locked","You don’t know her well enough for this.");
+		
 	}
 	else
 	{
@@ -1382,7 +1387,7 @@ public function bessFollowerMenu():void
 		}
 		else
 		{
-			addDisabledButton(5, "Date","Locked","It doens't look like [bess.name] wants to go on a date again anytime soon.");
+			addDisabledButton(5, "Date","Locked","It doens't seem like [bess.name] wants to go on a date ever again after the hassle on Ekurana.");
 		}
 	}
 
@@ -2086,8 +2091,15 @@ public function talkToBessAboutHairStyle():void
 		{
 			optSlot++;
 		}
-
-		addButton(i, StringUtil.toTitleCase(options[optSlot]), bessSetHairStyle, options[optSlot]);
+		// bessSetHairStyle() adds an article to some of the styles, so lets check both possibilities
+		if (options[optSlot] == bessHairStyle() || indefiniteArticle(options[optSlot]) == bessHairStyle())
+		{
+			addDisabledButton(i, StringUtil.toTitleCase(options[optSlot]));
+		}
+		else
+		{
+			addButton(i, StringUtil.toTitleCase(options[optSlot]), bessSetHairStyle, options[optSlot]);
+		}
 	}
 }
 


### PR DESCRIPTION
A couple of changes/fixes to bring Bess more in line with recent characters (and get rid of some annoyances)

-Hitting 'Back' in one of her customizing menu should always bring you to the previous/parent menu (some moved you directly to the 'Function' menu)
-'Functions' menu should always show the right output text (sometimes kept text of one of the sub menus)
-Changed buttons and threeshold values for hips and butt ratings (more in line with NPCs/PC and more distinct)
-'Dates' & 'Int. Sex' buttons are now called 'Locked' when first meeting Bess (keeping it in line with Paige and other NPCs)
-Added a tooltip to the 'Dates' button to inform the player when no more dates are available
-The buttons for the currently choosen hair color/style, eye color, bodyshape and similiar settings should always be disabled now