### PR TITLE
Kaede mini xpack

### DIFF
--- a/includes/follower/anno.as
+++ b/includes/follower/anno.as
@@ -169,7 +169,16 @@ public function annoFollowerApproach():void
 	clearOutput();
 	annoFollowerHeader();
 
-	if (hours >= 6 && hours <= 11 || hours >= 14 && hours <= 20) output("You give a light rap on Anno’s door, and are quickly let in. <i>“Hey, boss!”</i> she says with a smile, ushering you in. ")
+	//chance of walking in on ANNO and Kaede doing petplay
+	//Kaede must have 10+ Exhibitionism
+	if (flags["KAEDE_EXHIBITIONISM"] >= 10 && 
+		((hasMetKaede() && haveFuckedAnno() && flags["ANNOxKAEDE_LAST_DAY"] < days - 7 && shipLocation == "TAVROS HANGAR") || (kaedeCouldBeOnNewCanadaRepeats() && shipLocation == "CANADA1"))) {
+		annoXKaedeWalkinPetPlayIntro();
+	} 
+	else if (hours >= 6 && hours <= 11 || hours >= 14 && hours <= 20) 
+	{
+		output("You give a light rap on Anno’s door, and are quickly let in. <i>“Hey, boss!”</i> she says with a smile, ushering you in. ")
+	} 
 	else if (hours >= 12 || hours <= 13)
 	{
 		output("<i>“[pc.name]!”</i> she shouts over the din of a loud pop jam blaring from her computer, <i>“I didn’t see you there. I hope you didn’t mind my singing. It’s a new one from " + RandomInCollection("Touch Fluffy Tail", "The Beagles", "Playing Poker", "Buried Treasure") + " that I haven’t been able to get out of my head.”</i>");
@@ -195,51 +204,41 @@ public function annoFollowerApproach():void
 
 public function annoFollowerMenu():void
 {
-	//chance of walking in on ANNO and Kaede doing petplay
-	if ((hasMetKaede() && haveFuckedAnno() && flags["ANNOxKAEDE_LAST_DAY"] < days - 7 && shipLocation == "TAVROS HANGAR") ||
-		(kaedeCouldBeOnNewCanadaRepeats() && shipLocation == "CANADA1")) {
-		//random something
-		//annoXKaedeWalkinPetPlayIntro();
-	}
-	
-	if (haveFuckedAnno()) {
-		
-	} else {
-		annoFollowerHeader();
-	
-		clearMenu();
-		addButton(0, "Buy", annoFollowerBuyMenu, undefined, "Buy", "See what Anno has for sale.");
-		addButton(1, "Sell", annoFollowerSellMenu, undefined, "Sell", "See if you can sell any of your carried items to Anno.");
-		addButton(2, "Talk", annoFollowerTalkMenu, undefined, "Talk", "Talk to Anno about a variety of topics.");
-		addButton(3, "EarScritch", annoFollowerEarScritches, undefined, "Ear Scritches", "Give Anno an affectionate little pet.");
-		
-		addButton(5, "Appearance", annoFollowerAppearance, undefined, "Appearance", "Review what Anno’s entire body looks like.");
-		if (pcHasJunkPrize() && flags["ANNO_SCRAP_DISABLED"] == undefined) addButton(6, "Sell Prize", tryToSellAnnoSomeRaskScrapGuv, undefined, "Sell Prize", "Try to sell off the sweet loot you bought from the gang of raskvel males.");
-		else addDisabledButton(6, "Sell Prize", "Sell Prize", "This merchant isn’t interested in whatever you’re considering to be a prize.");
-		
-		if (pc.lust() >= 33) addButton(8, "Sex", annoFollowerSexMenu, undefined, "Sex","Have some sexy fun with Anno.");
-		else addDisabledButton(8, "Sex", "Sex", "Gotta get fired up before you can approach the snowy ausar for some ‘entertainment’.")
-		
-		if (flags["ANNO_SLEEPWITH_INTRODUCED"] != undefined)
-		{
-			if (haveFuckedAnno())
-			{
-				if (flags["CREWMEMBER_SLEEP_WITH"] == "ANNO") addButton(7, "No Sleep W.", annoSleepToggleOff, undefined, "Don’t Sleep With", "Tell Anno you’d like to sleep without her for now.");
-				else addButton(7, "Sleep With", annoSleepToggleOn, undefined, "Sleep With", "Tell Anno you’d like her to sleep with you in the evenings.");
-			}
-			else
-			{
-				addDisabledButton(7, "Sleep With", "Sleep With", "You could probably get a cuddly ausar bed-buddy if you had sex with her.");
-			}
-		}
-		else addDisabledButton(7, "Sleep With", "Sleep With", "A nice rest sounds good... maybe Anno might pay you a vist of her own accord in the process.");
-		
-		
-		if (InCollection(shipLocation, "TAVROS HANGAR", "SHIP HANGAR", "201", "500")) addButton(13, "Evict", annoFollowerBootOff, undefined, "Evict from Ship", "Tell Anno to get off the ship. You might break her heart a little, but you’ll probably be able to pick her up again later.");
-		else addDisabledButton(13, "Evict", "Evict from Ship", "You can’t bring yourself to kick Anno off your ship here. Head back to a mainline planet or station first.");
+	annoFollowerHeader();
 
-		addButton(14, "Back", crew);
+	clearMenu();
+	addButton(0, "Buy", annoFollowerBuyMenu, undefined, "Buy", "See what Anno has for sale.");
+	addButton(1, "Sell", annoFollowerSellMenu, undefined, "Sell", "See if you can sell any of your carried items to Anno.");
+	addButton(2, "Talk", annoFollowerTalkMenu, undefined, "Talk", "Talk to Anno about a variety of topics.");
+	addButton(3, "EarScritch", annoFollowerEarScritches, undefined, "Ear Scritches", "Give Anno an affectionate little pet.");
+	
+	addButton(5, "Appearance", annoFollowerAppearance, undefined, "Appearance", "Review what Anno’s entire body looks like.");
+	if (pcHasJunkPrize() && flags["ANNO_SCRAP_DISABLED"] == undefined) addButton(6, "Sell Prize", tryToSellAnnoSomeRaskScrapGuv, undefined, "Sell Prize", "Try to sell off the sweet loot you bought from the gang of raskvel males.");
+	else addDisabledButton(6, "Sell Prize", "Sell Prize", "This merchant isn’t interested in whatever you’re considering to be a prize.");
+	
+	if (pc.lust() >= 33) addButton(8, "Sex", annoFollowerSexMenu, undefined, "Sex","Have some sexy fun with Anno.");
+	else addDisabledButton(8, "Sex", "Sex", "Gotta get fired up before you can approach the snowy ausar for some ‘entertainment’.")
+	
+	if (flags["ANNO_SLEEPWITH_INTRODUCED"] != undefined)
+	{
+		if (haveFuckedAnno())
+		{
+			if (flags["CREWMEMBER_SLEEP_WITH"] == "ANNO") addButton(7, "No Sleep W.", annoSleepToggleOff, undefined, "Don’t Sleep With", "Tell Anno you’d like to sleep without her for now.");
+			else addButton(7, "Sleep With", annoSleepToggleOn, undefined, "Sleep With", "Tell Anno you’d like her to sleep with you in the evenings.");
+		}
+		else
+		{
+			addDisabledButton(7, "Sleep With", "Sleep With", "You could probably get a cuddly ausar bed-buddy if you had sex with her.");
+		}
 	}
+	else addDisabledButton(7, "Sleep With", "Sleep With", "A nice rest sounds good... maybe Anno might pay you a vist of her own accord in the process.");
+	
+	
+	if (InCollection(shipLocation, "TAVROS HANGAR", "SHIP HANGAR", "201", "500")) addButton(13, "Evict", annoFollowerBootOff, undefined, "Evict from Ship", "Tell Anno to get off the ship. You might break her heart a little, but you’ll probably be able to pick her up again later.");
+	else addDisabledButton(13, "Evict", "Evict from Ship", "You can’t bring yourself to kick Anno off your ship here. Head back to a mainline planet or station first.");
+
+	addButton(14, "Back", crew);
+	
 	
 }
 
@@ -4215,33 +4214,162 @@ public function annoFrenchMaidGimmeMoreMore(x:int):void
 public function annoXKaedeWalkinPetPlayIntro():void 
 {
 	clearOutput();
-	//
-	author("Savin");
-	
-	output("walking in");
-	clearMenu();
-	addButton(0, "Watch Them", watchAnnoXKaedeAccidentPetPlay, undefined, "Watch Them", "Let Kaede keep Anno on a short, sexy leash...");
-	//addButton(0, "Watch Them", watchAnnoXKaedeAccidentPetPlay, undefined, "Watch Them","Let Kaede keep Anno on a short, sexy leash...");
-	//addButton(1, "Collar Kaede", collarKaedeInAnnoXKaedeAccidentPetPlay, undefined, "Collar Kaede","Kaede's not really cut out for the whole "dominant" thing. Put her in a collar, too, and spend some quality time with the puppy pair." );
-}
-
-public function watchAnnoXKaedeAccidentPetPlay():void {
-	
-}
-
-public function collarKaedeInAnnoXKaedeAccidentPetPlay():void {
-	clearOutput();
 	showKaede();
 	author("Savin");
+	showName("ANNO &\nKAEDE");
+	kaedeIncreaseExhibitionism(3);
 	
-	output("walking in");
+	output("There's normally nothing special about heading over to Anno's cabin. She's pretty much had an open-door policy with you since coming aboard; it's not surprising when you find her door's actually jammed open. The automatic slide is stuck on what is most certainly a bright pink bra, trying and failing to seal closed around one of the cups. A cup that looks a little too small to be one of Anno's.");
+	output("\n\nAnd then you hear giggles, and a low little moan, drifting out from inside.");
+	output("\n\nCuriosity gets the better of you. You wander up to the door and press your eye into the crack, peering into the science ");
+	if (silly)
+		output(" doggo");
+	else 
+		output(" slut");
+	output("'s cabin. Inside, a very naked Anno is squatting on the deck, arms raised in front of her like paws and tongue lolling out of her mouth, panting heavily. Around her neck is a bit leather collar with a pink bone-shaped holotag, connected to a hardlight leash held by none other than than a certain ginger girlfriend, sitting on the edge of her bed.");
+	output("\n\n“Good girl!” Kaede giggles, scratching Anno between the ears. “Yes you are. The best girl!”");
+	output("\n\nAnno barks happily, wagging her snowy tail and nuzzling against Kaede's thigh.");
+	output("\n\n“Uh, let's see,” Kaede hums, tapping her chin. “Umm, why don't you, uh, oh I know! Roll over, girl! Roll over!”");
+	output("\n\nObediently, Anno rolls onto her back, arms and legs in the air -- and does so in a way that pushes her tits together with her shoulders and leaves her legs spread, tempting her girlfriend with her juicy slit. Kaede licks her lips, staring down at her slutty puppy with shameless lust in her eyes.");
+	output("\n\n“You're such a good girl,” Kaede coos, praising her pup with her eyes, wandering all over Anno curvaceous, naked form. “I think you deserve a treat.”");
+	output("\n\nAnno makes a cheerful “Woof,” and watches eagerly as Kaede stands up and unzips her jeans. Looks like Anno's gonna get a nice, juicy bone!");
+	output("\n\nJust as Kaede's pulling out her dick, though, she catches sight of you out of the corner of her eye... and screams, because of course the poor shy dear does when she realizes she's been caught with her cock out. Anno, though, just rolls her head back and blinks at you, tail still wagging. She doesn't <i>say</i> anything, but one of her “paws” waves at you while Kaede's distracted by her own embarrassment.");
+	output("\n\nConsidering you've already turned her into a blushing pile of nerves, you go ahead and slide the door open the rest of the way and saunter in. ");
+	output("\n\nKaede tries to cover up, but Anno's feet catch her, trapping her half-hard red rocket between her fluffy soles. Trapped, the poor ginger's finally forced to face you, staring at you with those big, blue eyes of hers.");
+	output("\n\n“H-hi, [pc.name],” she whimpers, shivering as Anno's feet move up and down her length, keeping her right where the petplay puppy wants her 'master.' “Um, w-what brings you here?”");
+	output("\n\n“Well, it's my ship,” you tell her, eyes wandering all over the pert nipples poking through her shirt and the throbbing erection caught in a fluffy vice. Kaede squirms, still off-guard, and mumbles something incoherent under her breath that sounds like “oh right.” You just reach over and pat her head, thinking of all the things you could do with her.");
+	
 	clearMenu();
+	addButton(0, "Watch Them", watchAnnoXKaedeAccidentPetPlay, undefined, "Watch Them", "Let Kaede keep Anno on a short, sexy leash...");
+	addButton(1, "Collar Kaede", collarKaedeInAnnoXKaedeAccidentPetPlay, "Collar Kaede", "Kaede's not really cut out for the whole “dominant” thing. Put her in a collar, too, and spend some quality time with the puppy pair.");
+}
+
+public function watchAnnoXKaedeAccidentPetPlay():void 
+{
+	clearOutput();
+	author("Savin");
+	showName("ANNO &\nKAEDE");
+	showBust(annoBustDisplay(true), "KAEDE_NUDE");
 	
-	//no reaha
-	addButton(0, "Next", reahaJoinsAnnoXKaedeAccidentPetPlay, undefined, "Watch Them","Let Kaede keep Anno on a short, sexy leash...");
+	if (pc.isAss() || pc.isBimbo()) 
+		output("“Who told you to stop, huh?” you grunt,");
+	else
+		output("“Don't let me stop you,” you smirk,");
+	output(" leaning over the dog-girl on all fours and grabbing the back of Kaede's head, pulling the randy shemale into a quick kiss. While she's busy in smooch town, you slip a hand down, first groping one of her perky little breasts, and then down to her pants. A little flick of the wrist and her jeans are crumpling to the floor, leaving her dick pressing against her panties until Anno pads forward and grabs them with her teeth, yanking them down and letting the half-hard rod of dogmeat flop free.");
+	output("\n\n“That's better,” you say, stepping back and eyeing Kaede's naked lower half. Anno paws at her thigh, making a whining sound until Kaede sighs and pulls the rest of her clothes off, tossing them on the bed. Once she's totally naked, and with Anno nuzzling and groping at her legs, it doesn't take long for her half-mast to get fully hard, jutting out from her crotch in a thick, throbbing pillar of dick. ");
+	output("\n\nKaede mumbles something, trying to focus her gaze exclusively on her pet puppy while you get comfortable at Anno's desk, watching them play. Kaede walks Anno through a few more tricks, getting back into the cadence of the roleplay, before finally telling Anno to roll over again, leaving the slut-puppy with her boobs and belly pointed up at the ginger domme. ");
+	output("\n\n“I-I guess you want a treat, right?” Kaede says, stepping forward. Anno makes a surprisingly-convincing bark, licking her lips as Kaede kneels down, straddling her lover's shoulders and depositing her cock right into the deep valley of her cleavage. Kaede's hands lock around Anno's tits, squeezing the plump mounds together around her length, letting just the tapered crown peek out from the marshmallow embrace.");
+	output("\n\n“Come get it, girl!” Kaede giggles, bucking her hips forward against the underside of Anno's tits. The crimson tip of her cock bobs with every shift of her hips. After a moment of watching, almost hypnotized by the wobbling wang, Anno finally leans in and plants her lips around the crown, giving her lover something warm and wet to thrust into. And thrust she does, moving her hips faster, slapping them against Anno's jiggling underboob. ");
+	output("\n\nThe way Anno feverishly licks and suckles on the tip of Kaede's cock, you'd think it was slathered in peanut butter! Her tongue lashes around the tip, flicking into every recess and lavishing every throbbing vein with all the love in her ausar heart. It isn't long before Kaede's moaning, softly at first, under her breath, but the more she thrusts and the more Anno blows her, the more virile her grunts and growls become.");
+	output("\n\nShe just needs a little encouragement to finish the job. ");
+	output("\n\nWhile Kaede's nice and distracted between Anno's tits, you slip out of your seat and saunter around behind the rutting pups, gently brushing Kaede's ginger tail out of the way as you get in behind her.");
+	output("\n\n“W-wha?” she manages to murmur before your hand  reaches out and slaps her ass, making her yelp -- and thrust hard into Anno's cleavage. Squeezing a handful of pert ass-flesh, you spread her backside open and drive the other hand in, pushing two fingers straight up Kaede's tailpipe. She yelps, tail thumping you in the face, but a moment later she's letting out a low moan of pleasure and pushing back on your fingers, taking them to the hilt in that tender ass of hers.");
+	output("\n\nTwo good thrusts and she's panting hard, groping at her own tits and hammering her hips into boob, then back against ass-spearing digits. Another few and her body goes rigid for a second, and then she's sinking back on your fingers with a contented sigh. Kaede's asshole clenches spasmodically around your digits, and the air takes on a familiar, richly thick texture as it wafts back around her slender body. You lean forward, nuzzling into Kaede's neck and looking over her shoulder, just in time to watch Anno licking off a glob of quivering white cream from her chin. Her tits and neck are slathered in it, rolling towards the deck in slow, meandering rivers of spunk.");
+	output("\n\nAnno sighs happily, resting her head back against the deck as Kaede leaks little aftershots onto her tits, shooting until her little sack is dry and her ass is finally managing to calm down. ");
+	output("\n\n“Good girls,” you croon, rubbing at Kaede's ear with your free hand. “Looks like you had fun.”");
+	output("\n\n“Y-yeah,” she laughs, leaning back against you. “Maybe I should let Anno talk me into things more often...”");
+	output("\n\n“Or maybe next time it'll be you in a collar.”");
+	output("\n\nYou leave Kaede with that thought to stew on.");
+
+	clearMenu();
+	addButton(0, "Next", mainGameMenu);
+}
+
+public function collarKaedeInAnnoXKaedeAccidentPetPlay():void 
+{
+	clearOutput();
+	author("Savin");
+	showName("ANNO &\nKAEDE");
+	showBust(annoBustDisplay(true), "KAEDE_NUDE");
+	
+	output("“You're so cute when you're flustered,” you tell her, leaning in and nipping at Kaede's ear. While you do, you reach over to Anno's desk and grab another collar and leash set. The ginger spacer's much too distracted to even notice you working the collar around her neck until you've locked it into place and give it a tug, pulling her into a quick but fierce kiss. “Now why don't you... sit.”");
+	output("\n\nKaede steps back, brushing the collar around her neck with a finger. “Wha-”");
+	output("\n\nYou shush her. “Puppies don't talk. Now sit!”");
+	output("\n\nThere's a moment of confusion, then indecision, before Kaede finally squats down beside you, opposite where Anno is still lying, awaiting instructions.");
+	output("\n\n“Oh, I didn't mean to forget about you!” you say, taking Anno's leash in your other hand. She yips and wags her tail, pressing her glorious chest-pillows together again for you: an invitation that just can't be refused. You reach down and grab one of her tits, squeezing it to the same rhythm that you might rub a real dog's belly. Once she's properly sated for the moment, you turn back to Kaede and, with a few quick motions, peel off her jacket and shirt, leaving only a plain white bra cupping her chest. Before you have to go fix that, Anno pounces on her lover like a real she-wolf, growling and nipping until a still very disoriented Kaede is face-down on her stomach. Anno tears her bra open, then off, with her teeth. Now that's talent!");
+	output("\n\nIf Anno had a dick, you're pretty sure she'd be humping Kaede right about now -- she's certainly got the subby puppy in the perfect position for it. Instead, though, she just helps you manhandle Kaede's pants off, leaving her knotty prick bobbing in the air. Getting rode roughshod by the two of you has her rock hard and ready; her knot's even starting to stiffen, begging to be thrust into a wet snatch. ");
+	output("\n\nInstead, it gets a vigorous sniffing from Anno, followed by a few experimental licks. Kaede gasps and shudders, trying not to talk. Instead, she makes a half-hearted “w-woof?” for you and flops her big ginger tail over Anno's head.");
+	output("\n\nBefore the two doggies can get too involved, you give both their leashes a little tug, barking for them both to sit. This time, Kaede's a little quicker on the draw, assuming the position next to her girlfriend with tail wagging, awaiting your order while her dick throbs hungrily between her folded legs. They're both eager for action, but you've got other plans: doggies gotta work for their treats, after all!");
+	output("\n\n“Alright, girls! Time to go for your walkies!”");
+	output("\n\nThey both bark and yip, following you right out of the cabin and towards the heart of the ship.");
+
+	clearMenu();
+	if (reahaIsCrew())
+		addButton(0, "Next", combineAndHaveAFinishAnnoXKaedeAccidentPetPlay);
+	else 
+		addButton(0, "Next", reahaJoinsAnnoXKaedeAccidentPetPlay);
+	
 }
 
 public function reahaJoinsAnnoXKaedeAccidentPetPlay():void 
 {
+	clearOutput();
+	author("Savin");
+	showName("ANNO & KAEDE &\nREAHA");
+	showBust(annoBustDisplay(true), "KAEDE_NUDE",reahaBustDisplay(true));
 	
+	IncrementFlag("SEXED_REAHA");
+	output("You've barely made it three paces out of the cabin, pulling the horny bitches behind you, when Reaha turns the corner out of the mess. She's topless");
+	if (reaha.isNude()) {
+		output(" as usual");
+	}
+	output(", carrying a magic milker under her arm that's pumping away at her puffy nipples. The cow-girl pauses in the middle of the corridor, blinks at the pair at your heels, and turns to you with a sensual grin on her lips.");
+	output("\n\n“Found some more pets, [pc.name]?” Reaha giggles. “Are they people-friendly?”");
+	output("\n\nAnno yips and bounces excitedly, soon joined by Kaede -- the latter motion making her dick bounce and shake, which inevitably draws Reaha's ever-lustful gaze. Deciding to play along, you nod and walk the girls up to meet their bovine neighbor. ");
+	output("\n\nReaha gives them an almost motherly smile and bends down, making her huge milky udders sway heavily underneath her. “Can you cuties do any tricks?”");
+	output("\n\nKaede and Anno share a look, and then in unison lean up and grab the hoses of Reaha's milker in their teeth, yanking the sucker-cups off with a pneumatic <i>pop</i> and a flood of [reaha.milk] that splatters all over the deck. Before Reaha can do more than utter a moo of surprise, the pair of slut-puppies lean up and latch onto her teats! ");
+	output("\n\n“O-oh!” Reaha gasps, shuddering hard enough to make those mammoth milkers jiggle in the girls' mouths. You can see the ausars' cheeks bulging with the rush of cow-girl cream, and they're soon struggling to keep up with Reaha's modded-up production.");
+	output("\n\n“Good doggies!” Reaha coos, stroking their hair. “Ohh, that feels good...”");
+	output("\n\nYou bet it does. Shifting the leashes both into one hand, you use the free one to cup Reaha's chin, lifting her gaze up to you before locking her in a long kiss. She moos softly, as much a moan as anything, and her hands wrap around your shoulders to hold you close. Between you, the naked puppy-girls keep suckling, keeping Reaha mooing in pleasure, her body quivering with their constant gropes and tugs.");
+	output("\n\nIt would be so easy to just bend the poor cow over and fuck her... or better yet, let Kaede mount her.");
+
+	clearMenu()
+	addButton(0, "Keep Walking", keepWalkingAnnoXKaedeAccidentPetPlay, undefined, "Keep Walking", "No time for Reaha. These doggies need their exercise...");
+	addButton(1, "Mount the Cow", mountCowAnnoXKaedeAccidentPetPlay, undefined, "Mount the Cow", "Let Kaede thrust that bone of hers into the cow-girl's cunny. This'll probably end your walk, in the best way possible.");
+}
+
+public function keepWalkingAnnoXKaedeAccidentPetPlay():void {
+	clearOutput();
+	author("Savin");
+	showName("ANNO & KAEDE &\nREAHA");
+	showBust(annoBustDisplay(true), "KAEDE_NUDE", reahaBustDisplay(true));
+	
+	output("“Come here, girl,” you say, taking Kaede's leash and urging her around to the backside of the cow-girl. The boob she was attached to bounces and leaks in the wake of Kaede's mouth, dripping milk all over Anno's shoulders and belly until the wanna-be dog nuzzles into the boob and starts milking with her hands.");
+	output("\n\nReaha makes a confused sound, but her mooing only grows lewder when you ");
+	if (!reaha.isCrotchExposed()) {
+		
+	} else {
+		
+	}
+	//{Reaha has pants: yank her [reaha.lowerGarment] down //else: give her big bovine booty a rough slap, right on her anchor tattoo}
+	
+	//combine
+	
+	
+	clearMenu();
+	addButton(0, "Next", combineAndHaveAFinishAnnoXKaedeAccidentPetPlay);
+}
+
+public function mountCowAnnoXKaedeAccidentPetPlay():void {
+	clearOutput();
+	author("Savin");
+	showName("ANNO & KAEDE &\nREAHA");
+	showBust(annoBustDisplay(true), "KAEDE_NUDE", reahaBustDisplay(true));
+	
+	
+	processTime(15 + rand(10));
+	pc.orgasm();
+
+	clearMenu();
+	addButton(0, "Next", mainGameMenu);
+}
+
+//[Next] from No Reaha crew leads here.
+//[Next] from KeepWalking also leads here
+public function combineAndHaveAFinishAnnoXKaedeAccidentPetPlay() {
+	
+	processTime(15 + rand(10));
+	pc.orgasm();
+	clearMenu();
+	addButton(0, "Next", mainGameMenu);
 }

--- a/includes/follower/anno.as
+++ b/includes/follower/anno.as
@@ -171,35 +171,38 @@ public function annoFollowerApproach():void
 
 	//chance of walking in on ANNO and Kaede doing petplay
 	//Kaede must have 10+ Exhibitionism
-	if (flags["KAEDE_EXHIBITIONISM"] >= 10 && 
-		((hasMetKaede() && haveFuckedAnno() && flags["ANNOxKAEDE_LAST_DAY"] < days - 7 && shipLocation == "TAVROS HANGAR") || (kaedeCouldBeOnNewCanadaRepeats() && shipLocation == "CANADA1"))) {
+	if (flags["KAEDE_EXHIBITIONISM"] >= 10 && rand(10) == 0 && flags["ANNOxKAEDE_LAST_DAY"] != undefined && flags["ANNOxKAEDE_LAST_DAY"] < days - 7 && ((hasMetKaede() && haveFuckedAnno()  && shipLocation == "TAVROS HANGAR") || (kaedeCouldBeOnNewCanadaRepeats() && shipLocation == "CANADA1"))) 
+	{
 		annoXKaedeWalkinPetPlayIntro();
 	} 
-	else if (hours >= 6 && hours <= 11 || hours >= 14 && hours <= 20) 
+	else 
 	{
-		output("You give a light rap on Anno’s door, and are quickly let in. <i>“Hey, boss!”</i> she says with a smile, ushering you in. ")
-	} 
-	else if (hours >= 12 || hours <= 13)
-	{
-		output("<i>“[pc.name]!”</i> she shouts over the din of a loud pop jam blaring from her computer, <i>“I didn’t see you there. I hope you didn’t mind my singing. It’s a new one from " + RandomInCollection("Touch Fluffy Tail", "The Beagles", "Playing Poker", "Buried Treasure") + " that I haven’t been able to get out of my head.”</i>");
-		output("\n\nShe gives you an apologetic grin as she flips the music off.");
+		if (hours >= 6 && hours <= 11 || hours >= 14 && hours <= 20) 
+		{
+			output("You give a light rap on Anno’s door, and are quickly let in. <i>“Hey, boss!”</i> she says with a smile, ushering you in. ")
+		} 
+		else if (hours >= 12 || hours <= 13)
+		{
+			output("<i>“[pc.name]!”</i> she shouts over the din of a loud pop jam blaring from her computer, <i>“I didn’t see you there. I hope you didn’t mind my singing. It’s a new one from " + RandomInCollection("Touch Fluffy Tail", "The Beagles", "Playing Poker", "Buried Treasure") + " that I haven’t been able to get out of my head.”</i>");
+			output("\n\nShe gives you an apologetic grin as she flips the music off.");
+		}
+		else output("You give a light rap on Anno’s door, which rocks back on its hinges, unlocked. Anno’s sleeping face-down on her desk. You give her a little poke, which quickly has her jerking her head up and rubbing the sleep from her eyes. <i>“Oh, shit. What time is it?”</i>");
+
+		if (!haveFuckedAnno()) output("\n\n<i>“So what’s up? You need anything?”</i>");
+		else
+		{
+			output("\n\nAnno plops down on the side of her bed, arms spread back to support her... which has the added bonus of thrusting her chest out against");
+			if (anno.armor is AnnosCatsuit) output(" the half-zipped front of her catsuit");
+			else output(" the low-cut neck of her blouse");
+			output(". <i>“Did you need something, babe?");
+			if (pc.lust() >= pc.lustMax() * 0.8) output(" Maybe a little stress relief?");
+			output("”</i>");
+		}
+
+		processTime(2);
+
+		annoFollowerMenu();
 	}
-	else output("You give a light rap on Anno’s door, which rocks back on its hinges, unlocked. Anno’s sleeping face-down on her desk. You give her a little poke, which quickly has her jerking her head up and rubbing the sleep from her eyes. <i>“Oh, shit. What time is it?”</i>");
-
-	if (!haveFuckedAnno()) output("\n\n<i>“So what’s up? You need anything?”</i>");
-	else
-	{
-		output("\n\nAnno plops down on the side of her bed, arms spread back to support her... which has the added bonus of thrusting her chest out against");
-		if (anno.armor is AnnosCatsuit) output(" the half-zipped front of her catsuit");
-		else output(" the low-cut neck of her blouse");
-		output(". <i>“Did you need something, babe?");
-		if (pc.lust() >= pc.lustMax() * 0.8) output(" Maybe a little stress relief?");
-		output("”</i>");
-	}
-
-	processTime(2);
-
-	annoFollowerMenu();
 }
 
 public function annoFollowerMenu():void
@@ -4213,10 +4216,11 @@ public function annoFrenchMaidGimmeMoreMore(x:int):void
 
 public function annoXKaedeWalkinPetPlayIntro():void 
 {
+	flags["ANNOxKAEDE_LAST_DAY"] = days;
 	clearOutput();
-	showKaede();
 	author("Savin");
 	showName("ANNO &\nKAEDE");
+	showBust(annoBustDisplay(true), "KAEDE_NUDE");
 	kaedeIncreaseExhibitionism(3);
 	
 	output("There's normally nothing special about heading over to Anno's cabin. She's pretty much had an open-door policy with you since coming aboard; it's not surprising when you find her door's actually jammed open. The automatic slide is stuck on what is most certainly a bright pink bra, trying and failing to seal closed around one of the cups. A cup that looks a little too small to be one of Anno's.");
@@ -4241,9 +4245,10 @@ public function annoXKaedeWalkinPetPlayIntro():void
 	
 	clearMenu();
 	addButton(0, "Watch Them", watchAnnoXKaedeAccidentPetPlay, undefined, "Watch Them", "Let Kaede keep Anno on a short, sexy leash...");
-	addButton(1, "Collar Kaede", collarKaedeInAnnoXKaedeAccidentPetPlay, "Collar Kaede", "Kaede's not really cut out for the whole “dominant” thing. Put her in a collar, too, and spend some quality time with the puppy pair.");
+	addButton(1, "Collar Kaede", collarKaedeInAnnoXKaedeAccidentPetPlay, undefined, "Collar Kaede", "Kaede's not really cut out for the whole “dominant” thing. Put her in a collar, too, and spend some quality time with the puppy pair.");
 }
 
+//[Watch Them]
 public function watchAnnoXKaedeAccidentPetPlay():void 
 {
 	clearOutput();
@@ -4271,10 +4276,18 @@ public function watchAnnoXKaedeAccidentPetPlay():void
 	output("\n\n“Or maybe next time it'll be you in a collar.”");
 	output("\n\nYou leave Kaede with that thought to stew on.");
 
+	pc.orgasm();
+	anno.orgasm();
+	
+	annoSexed(1);
+	flags["KAEDE_FUCKED"]++;	//has to exist because kaede has at least 10 exhibitionism
+	IncrementFlag("ANNO_X_KAEDE_THREESOMED");
+	
 	clearMenu();
 	addButton(0, "Next", mainGameMenu);
 }
 
+//[Collar Kaede]
 public function collarKaedeInAnnoXKaedeAccidentPetPlay():void 
 {
 	clearOutput();
@@ -4295,12 +4308,13 @@ public function collarKaedeInAnnoXKaedeAccidentPetPlay():void
 
 	clearMenu();
 	if (reahaIsCrew())
-		addButton(0, "Next", combineAndHaveAFinishAnnoXKaedeAccidentPetPlay);
-	else 
 		addButton(0, "Next", reahaJoinsAnnoXKaedeAccidentPetPlay);
+	else 
+		addButton(0, "Next", combineAndHaveAFinishAnnoXKaedeAccidentPetPlay);
 	
 }
 
+//[Next] if reaha is crew
 public function reahaJoinsAnnoXKaedeAccidentPetPlay():void 
 {
 	clearOutput();
@@ -4324,11 +4338,12 @@ public function reahaJoinsAnnoXKaedeAccidentPetPlay():void
 	output("\n\nIt would be so easy to just bend the poor cow over and fuck her... or better yet, let Kaede mount her.");
 
 	clearMenu()
-	addButton(0, "Keep Walking", keepWalkingAnnoXKaedeAccidentPetPlay, undefined, "Keep Walking", "No time for Reaha. These doggies need their exercise...");
+	addButton(0, "Keep Walking", combineAndHaveAFinishAnnoXKaedeAccidentPetPlay, undefined, "Keep Walking", "No time for Reaha. These doggies need their exercise...");
 	addButton(1, "Mount the Cow", mountCowAnnoXKaedeAccidentPetPlay, undefined, "Mount the Cow", "Let Kaede thrust that bone of hers into the cow-girl's cunny. This'll probably end your walk, in the best way possible.");
 }
 
-public function keepWalkingAnnoXKaedeAccidentPetPlay():void {
+//[Mount the Cow]
+public function mountCowAnnoXKaedeAccidentPetPlay():void {
 	clearOutput();
 	author("Savin");
 	showName("ANNO & KAEDE &\nREAHA");
@@ -4336,40 +4351,119 @@ public function keepWalkingAnnoXKaedeAccidentPetPlay():void {
 	
 	output("“Come here, girl,” you say, taking Kaede's leash and urging her around to the backside of the cow-girl. The boob she was attached to bounces and leaks in the wake of Kaede's mouth, dripping milk all over Anno's shoulders and belly until the wanna-be dog nuzzles into the boob and starts milking with her hands.");
 	output("\n\nReaha makes a confused sound, but her mooing only grows lewder when you ");
-	if (!reaha.isCrotchExposed()) {
-		
-	} else {
-		
-	}
-	//{Reaha has pants: yank her [reaha.lowerGarment] down //else: give her big bovine booty a rough slap, right on her anchor tattoo}
-	
-	//combine
-	
-	
-	clearMenu();
-	addButton(0, "Next", combineAndHaveAFinishAnnoXKaedeAccidentPetPlay);
-}
+	if (!reaha.isCrotchExposed())
+		output("yank her [reaha.lowerGarment] down");
+	else
+		output("give her big bovine booty a rough slap, right on her anchor tattoo");
+	output(". Kaede barks excitedly, and needs little encouragement once you push Reaha down, bending her over on top of the milk-drunk Anno. Reaha's tits swing, her tail lifts, and pretty soon there's a big ginger puppy leaping onto her back, red rocket prodding at the slit of her sex. You reach down and guide the tapered crown to its target, earning a cry of pleasure from Reaha and a husky grown from the bottom of Kaede's throat as she scrambles up onto the shortstack cow's back, thrusting deep into her silken slit.");
+	output("\n\n“Oooh! Good doggy!” Reaha giggles, putting a hand on your thigh to steady herself. “Unf, ah, yeah! [pc.name], I like your pets!”");
+	output("\n\nYou do too. Running a hand through Reaha's strawberry hair, you saunter back to her front and shuck off your gear. The cow-girls eyes wander hungrily up your body, and her hand slips from your [pc.leg] to your ");
+	if (pc.hasCock())
+		output("[pc.cock]");
+	else if (pc.hasVagina())
+		output("[pc.cunt]");
+	else
+		output("tender groin");
+	output(". A word of encouragement is all your lover needs to start ");
+	if (pc.hasCock())
+		output("running her tongue up the length of your [pc.cock], before taking the meaty shaft into her mouth and starting to suck.");
+	else 
+		output(" thrusting her tongue into your [pc.vagOrAss], exploring your body with that big, flat tongue of hers.");
+	output("\n\nNever one to be left out, Anno scoots around and ducks between Reaha's thick thighs, flicking her tongue at the cow-girls thick clit while her girlfriend pounds away at the pussy below it. All you need to do is murmur encouragements at them until you hear a gasp from around your sexual flesh, and a trickle of orgasmic feminine slime drools down Reaha's thigh. Her climax comes with a sutge of milk, so much that poor Anno can't possibly keep up -- she's bathed in [reaha.milk], rivers flowing down her own heaving breasts and forming pools in her ample curves, with a puddle of it quickly forming between her legs. Reaha's tongue moves faster, almost frantically trying to milk you as hard as she must be taking it.");
+	output("\n\nSpread out over Reaha's back, Kaede makes a soft little moan and bucks her hips one last time... and apparently wedges something nice and knotty deep in Reaha's fuckhole. The cow-girl's eyes go wide, and the rain of [reaha.milk] onto Anno's back becomes a cataclysmic flood that threatens to wash her away. Kaede, meanwhile, has clenched her eyes closed and is panting hard, shuddering as Reaha's quim milks her bone dry, and Kaede's knot traps every drop inside. ");
+	output("\n\n“S-sorry down there!” Reaha murmurs, switching to using her hand on you for a moment. “I guess it really was milking time.”");
+	output("\n\nAnno barks happily, reaching up and planting a long, wet lick on Reaha's cheek, before turning her oral attention to you. ");
+	output("\n\nBetween pup and bovine, it doesn't take long for you to get your happy ending too, ");
+	if (pc.hasCock())
+		output("showering the girls' faces with [pc.cum]. A few shots even manage to make it Kaede's way, smearing across her cheeks.");
+	else
+		output(" You're soon gasping and moaning, running your hands through the girls' hair and bucking your [pc.hips] as their tongues and lips do their way, bringing you to a swift, hard climax.");
+	output("\n\nIt's going to be a while before Kaede's knot deflates, so once you've come down from your orgasmic high, you help scoot the pair over to the couch in the main room, leaving Reaha holding Kaede's leash while you take Anno back to her room too cool off in each other's arms.");
 
-public function mountCowAnnoXKaedeAccidentPetPlay():void {
-	clearOutput();
-	author("Savin");
-	showName("ANNO & KAEDE &\nREAHA");
-	showBust(annoBustDisplay(true), "KAEDE_NUDE", reahaBustDisplay(true));
-	
-	
 	processTime(15 + rand(10));
 	pc.orgasm();
+	anno.orgasm();
+	
+	annoSexed(1);
+	flags["KAEDE_FUCKED"]++;	//has to exist because kaede has at least 10 exhibitionism
+	IncrementFlag("ANNO_X_KAEDE_THREESOMED");
 
 	clearMenu();
 	addButton(0, "Next", mainGameMenu);
 }
 
-//[Next] from No Reaha crew leads here.
-//[Next] from KeepWalking also leads here
-public function combineAndHaveAFinishAnnoXKaedeAccidentPetPlay() {
+//[Next]
+//[KeepWalking]
+public function combineAndHaveAFinishAnnoXKaedeAccidentPetPlay():void {
+	clearOutput();
+	output(String(flags["ANNOxKAEDE_LAST_DAY"]));
+	output(" days ");
+	//flags["ANNOxKAEDE_LAST_DAY"] < days - 7
+	output(String(days));
+	author("Savin");
+	if (reahaIsCrew())
+	{
+		//[KeepWalking] from reahaJoinsAnnoXKaedeAccidentPetPlay
+		showName("ANNO & KAEDE &\nREAHA");
+		showBust(annoBustDisplay(true), "KAEDE_NUDE", reahaBustDisplay(true));
+		
+		output("“Come on, girls! Leave Reaha alone,” you command, holding their leashes taut. Eventually, the puppy pair relent, popping off Reaha's boobs and leaving the milk-jugs leaking onto the floor. You give Reaha's butt a slap in passing and leave her to recover while you take your faithful hounds out towards the airlock.");
+		output("\n\n");
+	} 
+	else 
+	{
+		//[Next] from No Reaha crew leads here.
+		showName("ANNO &\nKAEDE");
+		showBust(annoBustDisplay(true), "KAEDE_NUDE");
+	}
 	
-	processTime(15 + rand(10));
+	output("The closer you get to the outside world, the more eagerly Anno's tail wags ");
+	if (flags["KAEDE_EXHIBITIONISM"] < 50) 
+		output("and the more resistant Kaede becomes. She pulls and tugs on her leash, digging her “paws” into the deck to try and keep you from dragging her out into public. But you've got plans for this puppy, and she isn't breaking character to ask you to stop!");
+	else 
+		output("and the harder Kaede's cock looks, bobbing between her legs with every four-legged steps. She's really getting into this!");
+	output("\n\nThe airlock cycles through, letting you lead Anno and Kaede out into the bustling docks. The snowy ausar lets out a cheery bark as she pads along beside you, drawing the attention of some of the spacers and dock-workers surrounding you. A mix of pride and arousal swells within you, feeling all their eyes on you... and the two naked ausar trotting along at your heels.");
+	output("\n\nThere's no sense getting yourself in actual trouble, so you keep it brief: one loop around the deck, enough to get the girls' hearts beating, and show them off in all their submissive beauty to the accumulated spacers. By the time you're back at the airlock, there's barely a set of trousers in the docks not tented by a boner, or a blouse not made lurid by diamond-stiff nipples poking through. A few of the onlookers throw catcalls at you, or reach down and pet the girls when you pass by -- or grab their asses, in some cases. Kaede's throbbing red rocket even gets a stroke from a particularly stacked dzaan.");
+	output("\n\nBy the time you get back to the airlock, Kaede's painfully hard, beading up with pre, and Anno's thighs are slick with her shameless excitement. The way they're eyeing each other, it's gonna be hard to keep them off each other... but you don't mind letting them paw and grope at each other, nuzzling into their tails and licking at what's underneath until the airlock cycles back, and the pair of them go tumbling in, already wrestling to see what of them's going to be top dog.");
+	output("\n\nThe airlock's barely closed before Anno's face is pushed onto the deck, ass raised and tail waving. You just release Kaede's leash and let her loose to lunge up onto her lover's back, slamming her dick into Anno's waiting quim. The snowy ausar howls with pleasure, squirming underneath the suddenly-feral Kaede while she's pounded into the deck. Kaede's tail thrashes eagerly behind the tangle of naked, sweaty bodies, thumping against the bulkheads with every thrust of her slender hips.");
+	output("\n\nLooks like you got yourself a breeding pair of bitches! At the rate they're going, you might just end up with a litter of puppies. Wouldn't that be something?");
+	output("\n\nWell, these doggies have been so good, you decide they deserve a ");
+	
+	if (pc.hasCock() || pc.lowerUndergarment.hardLightEquipped) 
+	{
+		output("bone.");
+		output("\n\nYou toss your gear aside and slide down onto your [pc.knees], presenting your [pc.cockOrStrapon] to Anno. The snowy slut pants, leaving her mouth open for you to exploit. Your dick slides forward, sliding over her oh-so-wet tongue and down her throat. She's as dutiful as ever, lavishing your length with loving licks and squeezing your crown with her throat, milking you as surely as her pussy must be working Kaede behind her. Your hands find their way to Anno's jackal-like ears, scratching that sweet spot between them until she's moaning -- and dripping between her legs, though that's just as much her stud's doing as it is yours");
+	}
+	else
+	{
+		output("juicy treat.")
+		output("\n\nYou toss your gear aside and turn around, bracing yourself against the bulkhead and presenting your [pc.vagOrAss]. Anno knows just what to do with a needy hole like yours, and pretty soon there's a long, wet ausar tongue flicking across your outer flesh, probing into your hungry depths when you reach back and start scratching between those big, perky ears of hers.");
+	}
+
+	output("\n\nWhile you're enjoying your sloppy oral, Kaede's starting to grunt and huff on her girlfriend's back, digging her fingers into Anno's ribs as she maintains the awkward, bestial position. Classic doggystyle, retro by several million years of evolution, but still good enough to leave the bitch on bottom moaning like a whore, begging with her body for more hard dick. A request that Kaede's lizard-brain is more than happy to indulge, slamming her throbbing red rocket home again and again until you feel Anno tense, and Kaede's hips stop abruptly while pushed up against her ass. ");
+	output("\n\nKnotty girl! You reach back and tousle Kaede's hair, enjoying the lust-addled expression she's sporting, tongue lolled out of her mouth. You can almost smell the cum leaking out of her puppy pecker, filling Anno's cunt with all that precious shemale cream.");
+	
+	output("\n\nAnd it's about time Anno earned herself another orgasm");
+	if (pc.hasCock()) 
+		output(" to splatter her face! ");
+	else
+		output(". ");
+	output("You plant your hand on Anno's head, pulling her flush against your [pc.skinFurScales] when you start to feel that familiar, wonderful need boiling up in your loins. There's been more than enough foreplay; you don't try to hold it back, letting Anno's wandering tongue drive you to orgasm. ");
+	if (pc.hasCock() || pc.hasVagina()) 
+		output("Cum splatters her face, smearing across her lush lips before dripping down onto the deck.");
+	output("You slump against the nearest bulkhead, letting pleasure roll through you until your moans echo throughout the ship.");
+	
+	output("\n\nWhen your climax finally passes, you let the girls' leashes go and slide down to a sitting position on the bulkhead, trying to catch your breath. A moment later, though, Anno's scooted herself up next to you, rolling onto her side so that her head rests in your lap, and Kaede -- still bound by the knot to her pussy -- nuzzles into your thigh behind her.");
+	output("\n\nGood girls...");
+
+	processTime(5 + rand(10));
 	pc.orgasm();
+	anno.orgasm();
+	
+	annoSexed(1);
+	flags["KAEDE_FUCKED"]++;	//has to exist because kaede has at least 10 exhibitionism
+	IncrementFlag("ANNO_X_KAEDE_THREESOMED");
+	
 	clearMenu();
 	addButton(0, "Next", mainGameMenu);
 }

--- a/includes/follower/anno.as
+++ b/includes/follower/anno.as
@@ -195,40 +195,52 @@ public function annoFollowerApproach():void
 
 public function annoFollowerMenu():void
 {
-	annoFollowerHeader();
-	
-	clearMenu();
-	addButton(0, "Buy", annoFollowerBuyMenu, undefined, "Buy", "See what Anno has for sale.");
-	addButton(1, "Sell", annoFollowerSellMenu, undefined, "Sell", "See if you can sell any of your carried items to Anno.");
-	addButton(2, "Talk", annoFollowerTalkMenu, undefined, "Talk", "Talk to Anno about a variety of topics.");
-	addButton(3, "EarScritch", annoFollowerEarScritches, undefined, "Ear Scritches", "Give Anno an affectionate little pet.");
-	
-	addButton(5, "Appearance", annoFollowerAppearance, undefined, "Appearance", "Review what Anno’s entire body looks like.");
-	if (pcHasJunkPrize() && flags["ANNO_SCRAP_DISABLED"] == undefined) addButton(6, "Sell Prize", tryToSellAnnoSomeRaskScrapGuv, undefined, "Sell Prize", "Try to sell off the sweet loot you bought from the gang of raskvel males.");
-	else addDisabledButton(6, "Sell Prize", "Sell Prize", "This merchant isn’t interested in whatever you’re considering to be a prize.");
-	
-	if (pc.lust() >= 33) addButton(8, "Sex", annoFollowerSexMenu, undefined, "Sex","Have some sexy fun with Anno.");
-	else addDisabledButton(8, "Sex", "Sex", "Gotta get fired up before you can approach the snowy ausar for some ‘entertainment’.")
-	
-	if (flags["ANNO_SLEEPWITH_INTRODUCED"] != undefined)
-	{
-		if (haveFuckedAnno())
-		{
-			if (flags["CREWMEMBER_SLEEP_WITH"] == "ANNO") addButton(7, "No Sleep W.", annoSleepToggleOff, undefined, "Don’t Sleep With", "Tell Anno you’d like to sleep without her for now.");
-			else addButton(7, "Sleep With", annoSleepToggleOn, undefined, "Sleep With", "Tell Anno you’d like her to sleep with you in the evenings.");
-		}
-		else
-		{
-			addDisabledButton(7, "Sleep With", "Sleep With", "You could probably get a cuddly ausar bed-buddy if you had sex with her.");
-		}
+	//chance of walking in on ANNO and Kaede doing petplay
+	if ((hasMetKaede() && haveFuckedAnno() && flags["ANNOxKAEDE_LAST_DAY"] < days - 7 && shipLocation == "TAVROS HANGAR") ||
+		(kaedeCouldBeOnNewCanadaRepeats() && shipLocation == "CANADA1")) {
+		//random something
+		//annoXKaedeWalkinPetPlayIntro();
 	}
-	else addDisabledButton(7, "Sleep With", "Sleep With", "A nice rest sounds good... maybe Anno might pay you a vist of her own accord in the process.");
 	
+	if (haveFuckedAnno()) {
+		
+	} else {
+		annoFollowerHeader();
 	
-	if (InCollection(shipLocation, "TAVROS HANGAR", "SHIP HANGAR", "201", "500")) addButton(13, "Evict", annoFollowerBootOff, undefined, "Evict from Ship", "Tell Anno to get off the ship. You might break her heart a little, but you’ll probably be able to pick her up again later.");
-	else addDisabledButton(13, "Evict", "Evict from Ship", "You can’t bring yourself to kick Anno off your ship here. Head back to a mainline planet or station first.");
+		clearMenu();
+		addButton(0, "Buy", annoFollowerBuyMenu, undefined, "Buy", "See what Anno has for sale.");
+		addButton(1, "Sell", annoFollowerSellMenu, undefined, "Sell", "See if you can sell any of your carried items to Anno.");
+		addButton(2, "Talk", annoFollowerTalkMenu, undefined, "Talk", "Talk to Anno about a variety of topics.");
+		addButton(3, "EarScritch", annoFollowerEarScritches, undefined, "Ear Scritches", "Give Anno an affectionate little pet.");
+		
+		addButton(5, "Appearance", annoFollowerAppearance, undefined, "Appearance", "Review what Anno’s entire body looks like.");
+		if (pcHasJunkPrize() && flags["ANNO_SCRAP_DISABLED"] == undefined) addButton(6, "Sell Prize", tryToSellAnnoSomeRaskScrapGuv, undefined, "Sell Prize", "Try to sell off the sweet loot you bought from the gang of raskvel males.");
+		else addDisabledButton(6, "Sell Prize", "Sell Prize", "This merchant isn’t interested in whatever you’re considering to be a prize.");
+		
+		if (pc.lust() >= 33) addButton(8, "Sex", annoFollowerSexMenu, undefined, "Sex","Have some sexy fun with Anno.");
+		else addDisabledButton(8, "Sex", "Sex", "Gotta get fired up before you can approach the snowy ausar for some ‘entertainment’.")
+		
+		if (flags["ANNO_SLEEPWITH_INTRODUCED"] != undefined)
+		{
+			if (haveFuckedAnno())
+			{
+				if (flags["CREWMEMBER_SLEEP_WITH"] == "ANNO") addButton(7, "No Sleep W.", annoSleepToggleOff, undefined, "Don’t Sleep With", "Tell Anno you’d like to sleep without her for now.");
+				else addButton(7, "Sleep With", annoSleepToggleOn, undefined, "Sleep With", "Tell Anno you’d like her to sleep with you in the evenings.");
+			}
+			else
+			{
+				addDisabledButton(7, "Sleep With", "Sleep With", "You could probably get a cuddly ausar bed-buddy if you had sex with her.");
+			}
+		}
+		else addDisabledButton(7, "Sleep With", "Sleep With", "A nice rest sounds good... maybe Anno might pay you a vist of her own accord in the process.");
+		
+		
+		if (InCollection(shipLocation, "TAVROS HANGAR", "SHIP HANGAR", "201", "500")) addButton(13, "Evict", annoFollowerBootOff, undefined, "Evict from Ship", "Tell Anno to get off the ship. You might break her heart a little, but you’ll probably be able to pick her up again later.");
+		else addDisabledButton(13, "Evict", "Evict from Ship", "You can’t bring yourself to kick Anno off your ship here. Head back to a mainline planet or station first.");
 
-	addButton(14, "Back", crew);
+		addButton(14, "Back", crew);
+	}
+	
 }
 
 public function annoSleepWithIntroduce():void
@@ -652,6 +664,7 @@ public function annoFollowerSellMenu():void
 
 public function annoFollowerTalkMenu(doOut:Boolean = true):void
 {
+	
 	if (doOut)
 	{
 		clearOutput();
@@ -4197,4 +4210,38 @@ public function annoFrenchMaidGimmeMoreMore(x:int):void
 	pc.orgasm();
 	
 	addButton(0, "Next", mainGameMenu);
+}
+
+public function annoXKaedeWalkinPetPlayIntro():void 
+{
+	clearOutput();
+	//
+	author("Savin");
+	
+	output("walking in");
+	clearMenu();
+	addButton(0, "Watch Them", watchAnnoXKaedeAccidentPetPlay, undefined, "Watch Them", "Let Kaede keep Anno on a short, sexy leash...");
+	//addButton(0, "Watch Them", watchAnnoXKaedeAccidentPetPlay, undefined, "Watch Them","Let Kaede keep Anno on a short, sexy leash...");
+	//addButton(1, "Collar Kaede", collarKaedeInAnnoXKaedeAccidentPetPlay, undefined, "Collar Kaede","Kaede's not really cut out for the whole "dominant" thing. Put her in a collar, too, and spend some quality time with the puppy pair." );
+}
+
+public function watchAnnoXKaedeAccidentPetPlay():void {
+	
+}
+
+public function collarKaedeInAnnoXKaedeAccidentPetPlay():void {
+	clearOutput();
+	showKaede();
+	author("Savin");
+	
+	output("walking in");
+	clearMenu();
+	
+	//no reaha
+	addButton(0, "Next", reahaJoinsAnnoXKaedeAccidentPetPlay, undefined, "Watch Them","Let Kaede keep Anno on a short, sexy leash...");
+}
+
+public function reahaJoinsAnnoXKaedeAccidentPetPlay():void 
+{
+	
 }

--- a/includes/holidayEvents/puppyslutmas.as
+++ b/includes/holidayEvents/puppyslutmas.as
@@ -1008,7 +1008,9 @@ public function puppyslutmasDanceWithAnno():void
 public function puppyslutmasDanceWithKaede():void
 {
 	clearOutput();
-
+	
+	kaedeIncreaseExhibitionism(5);
+	
 	showBust("KAEDE");
 	author("Savin");
 

--- a/includes/tarkus/anno.as
+++ b/includes/tarkus/anno.as
@@ -3750,6 +3750,8 @@ public function continueServicingKaedeWithAnno():void
 
 public function annoxKaedeWatch(inShop:Boolean = true):void
 {
+	kaedeIncreaseExhibitionism(3)
+	
 	clearOutput();
 	author("Savin");
 	showName("ANNO &\nKAEDE");

--- a/includes/uveto/kaede.as
+++ b/includes/uveto/kaede.as
@@ -354,8 +354,9 @@ public function uvetoKaedeTease():void
 	kaedeHeader();
 
 	//+Exhibitionism. If you track NPC stats like that, give +KaedeExhibitionism, too! She probably starts off really low.
+	kaedeIncreaseExhibitionism(10);
+	
 	//+Mischievous
-
 	pc.addMischievous(3);
 	pc.exhibitionism(5);
 

--- a/includes/vesperia/delOnVesperia.as
+++ b/includes/vesperia/delOnVesperia.as
@@ -1024,7 +1024,8 @@ public function delSlootybuttTrainingSrTheDoombringer():void
 	{
 		showName("DEL, KALLY,\n& KAEDE");
 		showBust(showDelString(true),"KAEDE_NUDE","KALLY_NUDE");
-
+		kaedeIncreaseExhibitionism(10);
+		
 		if(flags["KAEDE_DEL_TRAINING"] == undefined) output("\n\n<i>“Oh my god!”</i>");
 		else output("\n\n<i>“Again!?”</i>");
 		output("\n\nYou cast a glance to the door, and see Kaede standing just inside wrapped in nothing by a towel that leaves her alabaster cleavage and long, slender legs bare. Her ginger tail thumps wetly on the slicked floor, unintentionally dipping into the puddles of spunk spreading out from you and Del.");

--- a/includes/vesperia/kaede.as
+++ b/includes/vesperia/kaede.as
@@ -372,7 +372,10 @@ public function maximumTeaseTheSloot():void
 //would be nicer as a lambda expression, if AS3 supports such wichcraft
 public function justMaximumTeaseTheSloot():void
 {
-	output("\n\nShe gives you a look, stands up, and wraps her tail around her sullied crotch before hurrying out towards her ship. You just laugh to yourself and enjoy the rest of your drink.");
+	clearOutput();
+	showKaede();
+	author("Savin");
+	output("She gives you a look, stands up, and wraps her tail around her sullied crotch before hurrying out towards her ship. You just laugh to yourself and enjoy the rest of your drink.");
 	clearMenu();
 	addButton(0, "Next", mainGameMenu);
 }
@@ -383,9 +386,38 @@ public function ultraMaximumDeluxeTeaseTheSloot():void
 	clearOutput();
 	showKaede();
 	author("Savin");
-	
-	output("“Oh, no,“ you say, taking Kaede by the wrist when she tries to scurry off. “I've got a better idea.“");
-	
+	output("“Oh, no,” you say, taking Kaede by the wrist when she tries to scurry off. “I've got a better idea.”");
+	output("\n\nYou give her a tug, just enough to plant Kaede back in her seat. With your other hand, you reach down and yank down her fly, giving you access to the cum-soiled panties hiding underneath. Kaede yips and squirms, feeling your fingers crawling all over her cock; despite her murmured protestations, she manages to start stiffening before you've got your hands fully around her soiled underpants.");
+	output("\n\nWith one rough yank, you rip her panties right off, pulling them out through her fly in a bunched-up ball of cum-soaked linens. Kaede yelps in surprise, only just managing to cover her mouth. You flash her a mischievous grin and roll her panties around in your hand, squeezing just hard enough to make them <i>squick</i> lewdly, bubbling up a little of her still-warm jizz between your fingers.");
+	output("\n\n“Wow, you really made a mess!” you tease, tracing your other hand up Kaede's arm until you're running your fingers through the back of her ginger hair. No escape, now. “You'd better clean it up!”");
+	output("\n\nKaede looks at you wide-eyed, blushing like a rose. “You... you... I can't...”");
+	output("\n\n“You can,” you urge, putting her panties right in front of her face, so close that she can't breathe without getting a deep whiff of her own cum. You urge her with a gentle push from behind, mixed with encouraging words about what a dirty girl she is, and how hot it would be to see her eating her own cum in public. Considering how much of Kaede's inhibitions you've already worn down since you met, it doesn't take long before she gives you a little whimper and leans in, flicking her tongue out and into the mess of cloth between your fingers.");
+	output("\n\n“That's it. Good girl,” you murmur into her ear, scratching through her hair as you shift her panties around, exposing more and more lurid cumrag for her to clean. While she works, you gently turn her around on the barstool, facing her out into the bar. After all her whimpering and moaning, there's more than a few pairs of eyes on the both of you now... and at least a few of them figure out what's going on, between the massive bulge threatening to poke out of Kaede's pants and the smears of white all over your fingers.");
+	output("\n\nHopefully Kally won't notice what you're getting up to. But then, that's half the fun, isn't it -- the thrill of all these eyes on you and your blushing lover, getting hot under the collar at the sheer <i>taboo</i> of it... ");
+	if (pc.hasCock()) {
+		output("Now <i>you</i>'re starting to get hard!");
+	} else {
+		output("Pretty soon, Kaede's not the only one who's getting hot-and-bothered by the display you're putting on. You're real tempted to just grab the shameless little shemale and take her back to your ship... but that's a reward for after she debases herself.");
+	}
+	output("\n\nEventually, the ginger pupper's panties are pristine -- giant rip in them aside -- though now they're soaked with warm spittle rather than sperm. You can smell the musk of sex on Kaede's breath, moreso when you pull her into your lap and into a long, deep kiss. She's practically trembling, and her breath comes in ragged gasps around your [pc.lips]... and then catches in her throat when your hand traces down her chest to her crotch, delving into her still-undone fly and wrapping around the throbbing doggy-dick sheathed within. Now nobody in the bar could mistake what's going on, but you don't care anymore: let 'em look! It only makes you ");
+	if(pc.hasCock()) {
+		output("harder and ");
+	}
+	if (pc.hasVagina()) {
+		output("wetter.");
+	} else {
+		output("more turned on.");
+	}
+	output("\n\n“[pc.name]!” Kaede whines, tensing in your arms. “I c- I can't!”");
+	output("\n\n“Of course you can,” you reassure her, moving your wrist a little faster. “There's so many people watching now. You wouldn't want to let 'em down?”");
+	output("\n\nShe makes a little noise that's somewhere between a whimper and a growl, and her fluffy red tail starts moving a little at your incessant, sweet urgings. All eyes are on that bulging package now, watching as your hand runs up and down Kaede's veiny length, from knot to tapered tip, faster and faster until her feet are scrabbling against your [pc.legs] and her ears are tucked against her scalp. Every breath is a husky moan, barely stifled into her hands, until Kaede gasps, and you feel a heat building up in her rock-hard cock.");
+	output("\n\nCareful not to fully expose her rod, you shift your hand from her shaft to her crown, cupping it just in time for the first shot of hot lady-jizz to splash into your palm. The rest soon follows, ejaculating into your waiting hand amidst a chorus of whimpers and groans. Though a little of her orgasm manages to slip past, squirting out of her open fly or drooling down her thigh, you manage to catch most of the precious liquid load before you withdraw your hand.");
+	output("\n\n“Eat up, pup,” you say, lifting your hand out of her crotch and up to her lips, feeling the steamy cream sloshing in your grasp. Kaede doesn't even feign resistance to your commands by this point: she opens wide and flicks her tongue out, slurping up the fresh load of cum like the hungry she-wolf she is. You nuzzle into the slutty puppy's neck while she cleans you off, kissing at her bare skin and whispering soothing words of love and lust into those big, drooped ears of hers. By the time she's got you nice and clean, with only the faintest stickiness in your digits to remind you of what was once overflowing in your hand, Kaede's breath has calmed to a slower tempo, and though you can feel her heart still hammering in her chest, it feels like she's finally accustomed to her role as an exhibitionistic ouroboros of her own jizz.");
+	output("\n\n“You're the worst,” she murmurs when you pull your hand back, letting her slump heavily against you. “I swear, hanging out with you and Anno's gonna turn me into some kinda turbo-slut.”");
+	output("\n\nAs if she's not already. You give Kaede a swat on the ass, pushing her up and out of your lap. “Better go get cleaned up,” you tell her. “And Kaede?”");
+	output("\n\n“Yeah,” she says, already halfway out the door.");
+	output("\n\n“Your fly's undone.”");
+
 	clearMenu();
 	addButton(0, "Next", mainGameMenu);
 }

--- a/includes/vesperia/kaede.as
+++ b/includes/vesperia/kaede.as
@@ -6,6 +6,7 @@ STATUS: "Kaede Canada Cooldown" 	- Kaede is on cooldown after meeting.
 flags["KAEDE_CS_COUNTDOWN"]			- Set as game timestamp to track 14 time on station visit.
 									- Set to -1 when Kaede's Canadia Station vacation is over.
 flags["GLORYHOLED_KAEDE"]			- Counts time gloryholed Kaede... capped at 1 for now.
+flags["KAEDE_EXHIBITIONISM"]		- tracks the exhibitionism score of kaede. Range 0-100
 
 */
 public function kaedeCouldBeOnNewCanadaRepeats():Boolean
@@ -301,6 +302,7 @@ public function yesThatsEnoughKaede():void
 public function keepTailScritching():void
 {
 	clearOutput();
+	kaedeIncreaseExhibitionism(10);
 	showKaede();
 	author("Savin");
 	//Oh no. You’re not satisfied just yet...
@@ -341,6 +343,7 @@ public function keepTailScritching():void
 //This seems more like an asshole move. - FEN
 public function maximumTeaseTheSloot():void
 {
+	kaedeIncreaseExhibitionism(10);
 	clearOutput();
 	showKaede();
 	author("Savin");
@@ -351,13 +354,40 @@ public function maximumTeaseTheSloot():void
 	output("\n\nYou grin and tell her not to lie: she enjoyed herself.");
 	output("\n\n<i>“That’s not the point!”</i> she growls. Oh wow, she is beet red now! <i>“You can’t do that in public! I... people are staring!”</i>");
 	output("\n\nOnly because she’s not using her indoors voice. Nobody was looking until she started fussing, you tell her. She somehow flushes a little redder and rucks her big ol’ ausar ears against her head. <i>“Now I gotta go change. And take a cold shower.”</i>");
-	output("\n\nShe gives you a look, stands up, and wraps her tail around her sullied crotch before hurrying out towards her ship. You just laugh to yourself and enjoy the rest of your drink.");
+	
 	IncrementFlag("KAEDE_PUBLIC_SHAME");
 	processTime(4);
 	pc.lust(10);
 	pc.addHard(1);
 	clearMenu();
-	addButton(0,"Next",mainGameMenu);
+	if (flags["KAEDE_EXHIBITIONISM"] != undefined && flags["KAEDE_EXHIBITIONISM"] >= 30) {
+		addButton(0, "ULTRAMAX TEASE", ultraMaximumDeluxeTeaseTheSloot,undefined, "ULTRAMAX TEASE","Make Kaede clean herself up for the enjoyment of the other patrons.");
+		addButton(1, "Let Her Go", justMaximumTeaseTheSloot);
+	} else {
+		output("\n\nShe gives you a look, stands up, and wraps her tail around her sullied crotch before hurrying out towards her ship. You just laugh to yourself and enjoy the rest of your drink.");
+		addButton(0, "Next", mainGameMenu);
+	}
+}
+
+//would be nicer as a lambda expression, if AS3 supports such wichcraft
+public function justMaximumTeaseTheSloot():void
+{
+	output("\n\nShe gives you a look, stands up, and wraps her tail around her sullied crotch before hurrying out towards her ship. You just laugh to yourself and enjoy the rest of your drink.");
+	clearMenu();
+	addButton(0, "Next", mainGameMenu);
+}
+
+//[ULTRAMAX TEASE]
+public function ultraMaximumDeluxeTeaseTheSloot():void 
+{
+	clearOutput();
+	showKaede();
+	author("Savin");
+	
+	output("“Oh, no,“ you say, taking Kaede by the wrist when she tries to scurry off. “I've got a better idea.“");
+	
+	clearMenu();
+	addButton(0, "Next", mainGameMenu);
 }
 
 //Get a Room
@@ -711,6 +741,8 @@ public function kaedeAndAnnoServiceKaedeFromCanadia():void
 //Watch Them
 public function watchAnnoAndKaedeYaSloot():void
 {
+	kaedeIncreaseExhibitionism(3);
+	
 	clearOutput();
 	showName("ANNO &\nKAEDE");
 	showBust(annoBustDisplay(true), "KAEDE_NUDE");
@@ -770,6 +802,8 @@ public function timeRunsOutForKaede():void
 //Possible option when the player opts to man the gloryhole.
 public function kaedePopsIntoZeGloryHole():void
 {
+	kaedeIncreaseExhibitionism(5);
+	
 	clearOutput();
 	showKaede(true);
 	author("Savin");
@@ -800,4 +834,13 @@ public function kaedePopsIntoZeGloryHole():void
 	pc.lust(10);
 	clearMenu();
 	addButton(0,"Next",mainGameMenu);
+}
+
+//add to kaede's exhibitionism score. 
+//There is no smart way to put it, but here is the main payoff for high kaede exhibitionism
+//percentage from 0 to 100
+public function kaedeIncreaseExhibitionism(arg:int):void 
+{
+	if (flags["KAEDE_EXHIBITIONISM"] != undefined) flags["KAEDE_EXHIBITIONISM"] = 0;
+	flags["KAEDE_EXHIBITIONISM"] = Math.max(Math.min(flags["KAEDE_EXHIBITIONISM"] + arg, 100), 0);
 }

--- a/includes/vesperia/kaede.as
+++ b/includes/vesperia/kaede.as
@@ -873,6 +873,6 @@ public function kaedePopsIntoZeGloryHole():void
 //percentage from 0 to 100
 public function kaedeIncreaseExhibitionism(arg:int):void 
 {
-	if (flags["KAEDE_EXHIBITIONISM"] != undefined) flags["KAEDE_EXHIBITIONISM"] = 0;
+	if (flags["KAEDE_EXHIBITIONISM"] == undefined) flags["KAEDE_EXHIBITIONISM"] = 0;
 	flags["KAEDE_EXHIBITIONISM"] = Math.max(Math.min(flags["KAEDE_EXHIBITIONISM"] + arg, 100), 0);
 }


### PR DESCRIPTION
Implemented Savin's mini XPAC for Kaede: [google docs](https://docs.google.com/document/d/1HxK1wVuYOCjWZKF5HYliGvBueWmRVoLJn_CeYjPxmLw/edit#)
-Added a new Exhibitionism scene with Kaede on Vesperia
-Added Random Petplay scene with Anno, Kaede and optionally Reaha

It uses Kaede Exhbitionism flag. Different old scenes now increase her exhibitionism score.