### PR TITLE
Added Missing Check for Nyrea Eggs Status Effect

### DIFF
--- a/classes/Characters/PlayerCharacter.as
+++ b/classes/Characters/PlayerCharacter.as
@@ -615,7 +615,7 @@ package classes.Characters
 					fecundFigure(totalDays);
 				}
 				
-				if (hasStatusEffect("Nyrea Eggs") && fertility() > 0 && hasOvipositor())
+				if (hasStatusEffect("Nyrea Eggs") && fertility() > 0 && hasOvipositor()&&cumType == GLOBAL.FLUID_TYPE_NYREA_CUM)
 				{
 					nyreaEggStuff(totalDays);
 				}
@@ -1165,7 +1165,7 @@ package classes.Characters
 					removeStatusEffect("Nyrea Eggs");
 				}
 			}
-			else if(hasPerk("Nyrea Eggs") && hasOvipositor())
+			else if(hasPerk("Nyrea Eggs") && hasOvipositor()&&cumType == GLOBAL.FLUID_TYPE_NYREA_CUM)
 			{
 				// Regain permanent effect if has perk.
 				AddLogEvent(ParseText("You feel a familiar bloating in your body and discover that your [pc.cumNoun] has started producing nyrean eggs again!"), "passive", deltaT);

--- a/classes/Creature.as
+++ b/classes/Creature.as
@@ -3506,7 +3506,7 @@
 						}
 						kGAMECLASS.nutStatusCleanup();
 					}
-					if(statusEffectv1("Nyrea Eggs") > 0 && hasOvipositor())
+					if(statusEffectv1("Nyrea Eggs") > 0 && hasOvipositor()&&cumType==GLOBAL.FLUID_TYPE_NYREA_CUM)
 					{
 						var nyreaEggs:Number = Math.round((6 + rand(5)) * statusEffectv2("Nyrea Eggs"));
 						if ((statusEffectv1("Nyrea Eggs") - nyreaEggs) < 0) nyreaEggs = statusEffectv1("Nyrea Eggs");

--- a/includes/gameStats.as
+++ b/includes/gameStats.as
@@ -541,7 +541,7 @@ public function statisticsScreen(showID:String = "All"):void
 		{
 			output2("\n<b><u>Ovipositor Organs</u></b>");
 			output2("\n<b>* Total Count:</b> " + pc.totalOvipositors());
-			if(pc.statusEffectv1("Nyrea Eggs") > 0&&pc.cumType==GLOBAL.FLUID_TYPE_NYREA_CUM) output2("\n<b>* Fertility, Nyrean Eggs, Total:</b> " + pc.statusEffectv1("Nyrea Eggs"));
+			if(pc.hasStatusEffect("Nyrea Eggs")&&pc.cumType==GLOBAL.FLUID_TYPE_NYREA_CUM) output2("\n<b>* Fertility, Nyrean Eggs, Total:</b> " + pc.statusEffectv1("Nyrea Eggs"));
 			else
 			{
 				if(pc.eggCount() > 0) output2("\n<b>* Fertility, Ovipositor Eggs, Total:</b> " + pc.eggCount());

--- a/includes/gameStats.as
+++ b/includes/gameStats.as
@@ -541,7 +541,7 @@ public function statisticsScreen(showID:String = "All"):void
 		{
 			output2("\n<b><u>Ovipositor Organs</u></b>");
 			output2("\n<b>* Total Count:</b> " + pc.totalOvipositors());
-			if(pc.statusEffectv1("Nyrea Eggs") > 0&&cumType==GLOBAL.FLUID_TYPE_NYREA_CUM) output2("\n<b>* Fertility, Nyrean Eggs, Total:</b> " + pc.statusEffectv1("Nyrea Eggs"));
+			if(pc.statusEffectv1("Nyrea Eggs") > 0&&pc.cumType==GLOBAL.FLUID_TYPE_NYREA_CUM) output2("\n<b>* Fertility, Nyrean Eggs, Total:</b> " + pc.statusEffectv1("Nyrea Eggs"));
 			else
 			{
 				if(pc.eggCount() > 0) output2("\n<b>* Fertility, Ovipositor Eggs, Total:</b> " + pc.eggCount());

--- a/includes/gameStats.as
+++ b/includes/gameStats.as
@@ -541,10 +541,13 @@ public function statisticsScreen(showID:String = "All"):void
 		{
 			output2("\n<b><u>Ovipositor Organs</u></b>");
 			output2("\n<b>* Total Count:</b> " + pc.totalOvipositors());
-			if(pc.eggCount() > 0) output2("\n<b>* Fertility, Ovipositor Eggs, Total:</b> " + pc.eggCount());
-			if(pc.eggCount(-1) > 0) output2("\n<b>* Fertility, Ovipositor Eggs, Unfertilized, Total:</b> " + pc.eggCount(-1));
-			if(pc.eggCount(1) > 0) output2("\n<b>* Fertility, Ovipositor Eggs, Fertilized, Total:</b> " + pc.eggCount(1));
-			if(pc.statusEffectv1("Nyrea Eggs") > 0) output2("\n<b>* Fertility, Nyrean Eggs, Total:</b> " + pc.statusEffectv1("Nyrea Eggs"));
+			if(pc.statusEffectv1("Nyrea Eggs") > 0&&cumType==GLOBAL.FLUID_TYPE_NYREA_CUM) output2("\n<b>* Fertility, Nyrean Eggs, Total:</b> " + pc.statusEffectv1("Nyrea Eggs"));
+			else
+			{
+				if(pc.eggCount() > 0) output2("\n<b>* Fertility, Ovipositor Eggs, Total:</b> " + pc.eggCount());
+				if(pc.eggCount(-1) > 0) output2("\n<b>* Fertility, Ovipositor Eggs, Unfertilized, Total:</b> " + pc.eggCount(-1));
+				if(pc.eggCount(1) > 0) output2("\n<b>* Fertility, Ovipositor Eggs, Fertilized, Total:</b> " + pc.eggCount(1));
+			}
 		}
 		
 		// Belly


### PR DESCRIPTION
Nyrea Egg Status effect was not properly checking if pc.cumType was nyrea cum. Thus you would be spitting out Nyrea eggs if you had any ovipositor organ at all.

Also changes were made to prevent nyrea eggs along with other eggs from displaying in codex stats in improper situations.