### PR TITLE
Fixed logic flip with azraRecruited()

### DIFF
--- a/includes/gameStats.as
+++ b/includes/gameStats.as
@@ -7752,7 +7752,7 @@ public function displayEncounterLog(showID:String = "All"):void
 		if(flags["MET_AZRA"] != undefined)
 		{
 			output2("\n<b>* Azra:</b> Met her");
-			if(!azraRecruited())
+			if(azraRecruited())
 			{
 				output2(", Crew member");
 				if(azraIsCrew()) output2(" (Onboard Ship)");


### PR DESCRIPTION
Fixed Azra being called a crew member if she wasn't one, and not being called one if she was
(Unless I'm reading this wrong and it was intentional for some reason)