### PR TITLE
New parsers (documentation in description)

### DIFF
--- a/classes/Creature.as
+++ b/classes/Creature.as
@@ -1982,8 +1982,7 @@
 				case "rangedNoun":
 				case "gunNoun":
 				case "bowNoun":
-					var gName = rangedWeapon.longName.split(" ");
-					buffer = gName[gName.length - 1];
+					buffer = getRangedNoun();
 					break;
 				case "mainWeapon":
 				case "weaponMain":
@@ -3420,6 +3419,30 @@
 			if(!(rangedWeapon is EmptySlot) && !(rangedWeapon is Rock) && ((meleeWeapon is EmptySlot) || (meleeWeapon is Rock))) return rangedWeapon.longName;
 			if(!(meleeWeapon is EmptySlot) && !(meleeWeapon is Rock) && ((rangedWeapon is EmptySlot) || (rangedWeapon is Rock))) return meleeWeapon.longName;
 			return getWeaponName(true);
+		}
+
+		public function getRangedNoun():String
+		{
+			if(!(rangedWeapon is EmptySlot))
+			{
+				if (rangedWeapon is Rock) return "rock"
+				if(rangedWeapon.hasFlag(GLOBAL.ITEM_FLAG_BOW_WEAPON)) return "bow";
+				var nouns:Array = ["gun"];
+				if(rangedWeapon.hasFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON)) nouns.push("rifle");
+				if(rangedWeapon.hasFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON)) nouns.push("pistol");
+				
+				//This portion adds the last actual word in the gun's name to the pool. For example, if you have a Buttcannon 1000, it will push "Buttcannon" because the string can't be converted to a number. 
+				//Because of TiTS longname conventions of having the MK version at the front of a long name for weapons in all cases that exist (ie. MK.VII Goovolver), this should be fine. 
+				//If it becomes a problem later, it can be easily commented out or deleted, but at current, the expanded pool of nouns is a decent QOL feature.
+				
+				var gName:Array = rangedWeapon.longName.split(" ");
+				var nameDesc:String = gName[gName.length - 1];
+				if(!isNan(Number(nameDesc))) nameDesc = gName[gName.length - 2];
+				nouns.push(nameDesc);
+
+				return RandomInCollection(nouns);
+			}
+			return "fists";
 		}
 		
 		public function weaponActionReady(present:Boolean = false, weapon:String = "", full:Boolean = true):String

--- a/classes/Creature.as
+++ b/classes/Creature.as
@@ -3430,15 +3430,18 @@
 				var nouns:Array = ["gun"];
 				if(rangedWeapon.hasFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON)) nouns.push("rifle");
 				if(rangedWeapon.hasFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON)) nouns.push("pistol");
+				if(rangedWeapon.hasFlag(GLOBAL.ITEM_FLAG_SHOTGUN_WEAPON)) nouns.push("shotgun");
+				if(rangedWeapon.hasFlag(GLOBAL.ITEM_FLAG_THROWER_WEAPON)) nouns.push("thrower");
+				if(rangedWeapon.hasFlag(GLOBAL.ITEM_FLAG_LAUNCHER_WEAPON)) nouns.push("launcher");
 				
-				//This portion adds the last actual word in the gun's name to the pool. For example, if you have a Buttcannon 1000, it will push "Buttcannon" because the string can't be converted to a number. 
-				//Because of TiTS longname conventions of having the MK version at the front of a long name for weapons in all cases that exist (ie. MK.VII Goovolver), this should be fine. 
-				//If it becomes a problem later, it can be easily commented out or deleted, but at current, the expanded pool of nouns is a decent QOL feature.
+				//Basically checks if the last word in a weapons name is a number and if it isn't, adds that to the list of possible outputs.
+				//Makes for a far nicer pool, and covers some more details than just "rifle" and the like.
+				//Doesn't work with things like MK.IV, but the current ranged weapon convention has that at the front of the long range
 				
 				var gName:Array = rangedWeapon.longName.split(" ");
 				var nameDesc:String = gName[gName.length - 1];
-				if(!isNan(Number(nameDesc))) nameDesc = gName[gName.length - 2];
-				nouns.push(nameDesc);
+				if(isNan(Number(nameDesc))) nouns.push(nameDesc);
+				
 
 				return RandomInCollection(nouns);
 			}

--- a/classes/Creature.as
+++ b/classes/Creature.as
@@ -1979,6 +1979,12 @@
 				case "weaponRanged":
 					buffer = rangedWeapon.longName;
 					break;
+				case "rangedNoun":
+				case "gunNoun":
+				case "bowNoun":
+					var gName = rangedWeapon.longName.split(" ");
+					buffer = gName[gName.length - 1];
+					break;
 				case "mainWeapon":
 				case "weaponMain":
 				case "weaponStat":
@@ -2566,6 +2572,12 @@
 					break;
 				case "ballNounSimple":
 					buffer = ballsNounSimple(true);
+					break;
+				case "ballsNounIsAre":
+					buffer = ballsNoun() + " " + (balls == 1 ? "is" : "are");
+					break;
+				case "ballsNounSimpleIsAre":
+					buffer = ballsNounSimple() + " " + (balls == 1 ? "is" : "are");
 					break;
 				case "ball":
 					buffer = ballsDescript();

--- a/classes/GLOBAL.as
+++ b/classes/GLOBAL.as
@@ -1218,6 +1218,9 @@
 		public static const ITEM_FLAG_STRETCHY:int						= 35; // Increases sexiness buff if related body part is big. Doubles as Transparent flag at 20+;
 		public static const ITEM_FLAG_RIFLE_WEAPON:int					= 36; //For outputing that a gun is a rifle
 		public static const ITEM_FLAG_PISTOL_WEAPON:int					= 37; //For outputing that a gun is a pistol
+		public static const ITEM_FLAG_SHOTGUN_WEAPON:int				= 38; //For outputing that a gun is a shotgun
+		public static const ITEM_FLAG_THROWER_WEAPON:int				= 39; //For outputing that a gun is a thrower
+		public static const ITEM_FLAG_LAUNCHER_WEAPON:int				= 40; //For outputing that a gun is a Launcher
 		
 		public static const ITEM_FLAG_NAMES:Array = [
 			"Bow Weapon",
@@ -1258,6 +1261,9 @@
 			"Stretchable",
 			"Rifle",
 			"Pistol",
+			"Shotgun",
+			"Thrower",
+			"Launcher"
 		];
 		
 		/**

--- a/classes/GLOBAL.as
+++ b/classes/GLOBAL.as
@@ -1216,7 +1216,8 @@
 		public static const ITEM_FLAG_SMALL_DICK_ONLY:int               = 33; //Cocksock can only be equipped by smol
 		public static const ITEM_FLAG_SHELTER:int						= 34; // For items that regulate environmental effects.
 		public static const ITEM_FLAG_STRETCHY:int						= 35; // Increases sexiness buff if related body part is big. Doubles as Transparent flag at 20+;
-
+		public static const ITEM_FLAG_RIFLE_WEAPON:int					= 36; //For outputing that a gun is a rifle
+		public static const ITEM_FLAG_PISTOL_WEAPON:int					= 37; //For outputing that a gun is a pistol
 		
 		public static const ITEM_FLAG_NAMES:Array = [
 			"Bow Weapon",
@@ -1255,6 +1256,8 @@
 			"Requires Small Cock",
 			"Shelter",
 			"Stretchable",
+			"Rifle",
+			"Pistol",
 		];
 		
 		/**

--- a/classes/Items/Guns/AcidLauncher.as
+++ b/classes/Items/Guns/AcidLauncher.as
@@ -45,6 +45,7 @@
 			baseDamage.corrosive.damageValue = 29;
 			//baseDamage.addFlag(DamageFlag.NO_CRIT);
 			//addFlag(GLOBAL.ITEM_FLAG_BLIND_IGNORE);
+			this.addFlag(GLOBAL.ITEM_FLAG_LAUNCHER_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/AcidRifle.as
+++ b/classes/Items/Guns/AcidRifle.as
@@ -45,6 +45,7 @@
 			baseDamage.corrosive.damageValue = 15;
 			//baseDamage.addFlag(DamageFlag.NO_CRIT);
 			//addFlag(GLOBAL.ITEM_FLAG_BLIND_IGNORE);
+			this.addFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/AcidThrower.as
+++ b/classes/Items/Guns/AcidThrower.as
@@ -45,6 +45,7 @@
 			baseDamage.corrosive.damageValue = 17;
 			baseDamage.addFlag(DamageFlag.NO_CRIT);
 			addFlag(GLOBAL.ITEM_FLAG_BLIND_IGNORE);
+			this.addFlag(GLOBAL.ITEM_FLAG_THROWER_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/AegisLightMG.as
+++ b/classes/Items/Guns/AegisLightMG.as
@@ -48,6 +48,7 @@ package classes.Items.Guns
 			baseDamage.addFlag(DamageFlag.BULLET);
 			addFlag(GLOBAL.ITEM_FLAG_POWER_ARMOR);
 			addFlag(GLOBAL.ITEM_FLAG_EFFECT_FLURRYBONUS);
+			this.addFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON);
 			baseDamage.addFlag(DamageFlag.NO_CRIT);
 			
 			this.defense = 0;

--- a/classes/Items/Guns/ApolloPlasmaRifle.as
+++ b/classes/Items/Guns/ApolloPlasmaRifle.as
@@ -49,6 +49,7 @@
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			baseDamage.addFlag(DamageFlag.CHANCE_APPLY_BURN);
 			this.addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/ArcCaster.as
+++ b/classes/Items/Guns/ArcCaster.as
@@ -47,6 +47,7 @@ package classes.Items.Guns
 			baseDamage.electric.damageValue = 22;
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			this.addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/AutoShotgun.as
+++ b/classes/Items/Guns/AutoShotgun.as
@@ -46,6 +46,7 @@
 			baseDamage.addFlag(DamageFlag.BULLET);
 			//baseDamage.addFlag(DamageFlag.NO_CRIT);
 			//addFlag(GLOBAL.ITEM_FLAG_EFFECT_FLURRYBONUS);
+			this.addFlag(GLOBAL.ITEM_FLAG_SHOTGUN_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/BlackLight.as
+++ b/classes/Items/Guns/BlackLight.as
@@ -50,6 +50,7 @@ package classes.Items.Guns
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			baseDamage.addFlag(DamageFlag.LASER);
 			this.addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/BlizzardCryrothrower.as
+++ b/classes/Items/Guns/BlizzardCryrothrower.as
@@ -45,6 +45,7 @@
 			baseDamage.freezing.damageValue = 16;
 			baseDamage.addFlag(DamageFlag.NO_CRIT);
 			addFlag(GLOBAL.ITEM_FLAG_BLIND_IGNORE);
+			this.addFlag(GLOBAL.ITEM_FLAG_THOWER_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/BoltActionRifle.as
+++ b/classes/Items/Guns/BoltActionRifle.as
@@ -44,6 +44,7 @@
 			
 			baseDamage.kinetic.damageValue = 23;
 			baseDamage.addFlag(DamageFlag.BULLET);
+			this.addFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/BothriocRifle.as
+++ b/classes/Items/Guns/BothriocRifle.as
@@ -44,6 +44,7 @@
 			baseDamage = new TypeCollection();
 			baseDamage.kinetic.damageValue = 14;
 			baseDamage.addFlag(DamageFlag.BULLET);
+			this.addFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/ChironexScourge.as
+++ b/classes/Items/Guns/ChironexScourge.as
@@ -46,6 +46,7 @@
 			baseDamage.poison.damageValue = 15;
 			//baseDamage.addFlag(DamageFlag.NO_CRIT);
 			//addFlag(GLOBAL.ITEM_FLAG_BLIND_IGNORE);
+			this.addFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/CryroPistol.as
+++ b/classes/Items/Guns/CryroPistol.as
@@ -44,7 +44,8 @@
 			baseDamage = new TypeCollection();
 			baseDamage.freezing.damageValue = 8;
 			//baseDamage.addFlag(DamageFlag.BULLET);
-			
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
+
 			this.defense = 0;
 			this.shieldDefense = 0;
 			this.shields = 0;

--- a/classes/Items/Guns/CryroRifle.as
+++ b/classes/Items/Guns/CryroRifle.as
@@ -44,6 +44,7 @@
 			baseDamage = new TypeCollection();
 			baseDamage.freezing.damageValue = 13;
 			//baseDamage.addFlag(DamageFlag.BULLET);
+			this.addFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/CustomLP17.as
+++ b/classes/Items/Guns/CustomLP17.as
@@ -51,6 +51,7 @@ package classes.Items.Guns
 			baseDamage.addFlag(DamageFlag.LASER);
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			this.addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/EagleHandgun.as
+++ b/classes/Items/Guns/EagleHandgun.as
@@ -44,6 +44,7 @@
 			
 			baseDamage.kinetic.damageValue = 6;
 			baseDamage.addFlag(DamageFlag.BULLET);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/ElectroLauncher.as
+++ b/classes/Items/Guns/ElectroLauncher.as
@@ -46,6 +46,7 @@
 			baseDamage.electric.damageValue = 29;
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			this.addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_LAUNCHER_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/Electrogun.as
+++ b/classes/Items/Guns/Electrogun.as
@@ -46,6 +46,7 @@
 			baseDamage.electric.damageValue = 13;
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			this.addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/EmmysSalamanderPistol.as
+++ b/classes/Items/Guns/EmmysSalamanderPistol.as
@@ -49,6 +49,7 @@
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			baseDamage.addFlag(DamageFlag.LASER);
 			addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/EmmysSalamanderRifle.as
+++ b/classes/Items/Guns/EmmysSalamanderRifle.as
@@ -50,6 +50,7 @@
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			baseDamage.addFlag(DamageFlag.LASER);
 			addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/EmmysSalamanderRifle2.as
+++ b/classes/Items/Guns/EmmysSalamanderRifle2.as
@@ -49,6 +49,7 @@
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			baseDamage.addFlag(DamageFlag.LASER);
 			addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/Flamethrower.as
+++ b/classes/Items/Guns/Flamethrower.as
@@ -45,6 +45,7 @@
 			baseDamage.burning.damageValue = 8;
 			baseDamage.addFlag(DamageFlag.NO_CRIT);
 			addFlag(GLOBAL.ITEM_FLAG_BLIND_IGNORE);
+			this.addFlag(GLOBAL.ITEM_FLAG_THOWER_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/FlamethrowerII.as
+++ b/classes/Items/Guns/FlamethrowerII.as
@@ -45,6 +45,7 @@
 			baseDamage.burning.damageValue = 16;
 			baseDamage.addFlag(DamageFlag.NO_CRIT);
 			addFlag(GLOBAL.ITEM_FLAG_BLIND_IGNORE);
+			this.addFlag(GLOBAL.ITEM_FLAG_THROWER_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/Goovolver.as
+++ b/classes/Items/Guns/Goovolver.as
@@ -56,6 +56,7 @@ package classes.Items.Guns
 			this.fortification = 0;
 			
 			addFlag(GLOBAL.ITEM_FLAG_LUST_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.version = _latestVersion;
 			

--- a/classes/Items/Guns/HammerCarbine.as
+++ b/classes/Items/Guns/HammerCarbine.as
@@ -44,6 +44,7 @@
 			baseDamage = new TypeCollection();
 			baseDamage.kinetic.damageValue = 12;
 			baseDamage.addFlag(DamageFlag.BULLET);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);			
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/HammerPistol.as
+++ b/classes/Items/Guns/HammerPistol.as
@@ -44,6 +44,7 @@
 			baseDamage = new TypeCollection();
 			baseDamage.kinetic.damageValue = 9;
 			baseDamage.addFlag(DamageFlag.BULLET);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/HammerPistolScavenged.as
+++ b/classes/Items/Guns/HammerPistolScavenged.as
@@ -44,6 +44,7 @@
 			baseDamage = new TypeCollection();
 			baseDamage.kinetic.damageValue = 9;
 			baseDamage.addFlag(DamageFlag.BULLET);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/HandCannon.as
+++ b/classes/Items/Guns/HandCannon.as
@@ -45,6 +45,7 @@
 			baseDamage.kinetic.damageValue = 14;
 			baseDamage.burning.damageValue = 13;
 			baseDamage.addFlag(DamageFlag.BULLET);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/HardlightRifle.as
+++ b/classes/Items/Guns/HardlightRifle.as
@@ -50,7 +50,8 @@
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			baseDamage.addFlag(DamageFlag.LASER);
 			addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
-			
+			this.addFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON);
+
 			this.defense = 0;
 			this.shieldDefense = 0;
 			this.shields = 0;

--- a/classes/Items/Guns/HeavyLaser.as
+++ b/classes/Items/Guns/HeavyLaser.as
@@ -48,6 +48,7 @@
 			baseDamage.addFlag(DamageFlag.LASER);
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			this.addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/HoldOutPistol.as
+++ b/classes/Items/Guns/HoldOutPistol.as
@@ -44,6 +44,7 @@
 			
 			baseDamage.kinetic.damageValue = 5;
 			baseDamage.addFlag(DamageFlag.BULLET);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/HoldoutHP.as
+++ b/classes/Items/Guns/HoldoutHP.as
@@ -48,6 +48,7 @@ package classes.Items.Guns
 			baseDamage = new TypeCollection();
 			baseDamage.kinetic.damageValue = 11;
 			baseDamage.addFlag(DamageFlag.PENETRATING);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/HuntingRifle.as
+++ b/classes/Items/Guns/HuntingRifle.as
@@ -43,6 +43,7 @@
 			
 			baseDamage.kinetic.damageValue = 21;
 			baseDamage.addFlag(DamageFlag.BULLET);
+			this.addFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/KhansArcCaster.as
+++ b/classes/Items/Guns/KhansArcCaster.as
@@ -47,6 +47,7 @@ package classes.Items.Guns
 			baseDamage.electric.damageValue = 25;
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			this.addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/LaserCarbine.as
+++ b/classes/Items/Guns/LaserCarbine.as
@@ -48,6 +48,7 @@
 			baseDamage.addFlag(DamageFlag.LASER);
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			this.addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/LaserPistol.as
+++ b/classes/Items/Guns/LaserPistol.as
@@ -48,6 +48,7 @@
 			baseDamage.addFlag(DamageFlag.LASER);
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			this.addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/LashCannon.as
+++ b/classes/Items/Guns/LashCannon.as
@@ -46,6 +46,7 @@ package classes.Items.Guns
 			this.baseDamage.electric.damageValue = 18;
 			this.baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			this.baseDamage.addFlag(DamageFlag.DRAINING);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.critBonus = 5;
 			

--- a/classes/Items/Guns/MagnumPistol.as
+++ b/classes/Items/Guns/MagnumPistol.as
@@ -44,6 +44,8 @@
 			
 			baseDamage.kinetic.damageValue = 11;
 			baseDamage.addFlag(DamageFlag.BULLET);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
+			
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/MyrRifle.as
+++ b/classes/Items/Guns/MyrRifle.as
@@ -44,6 +44,7 @@
 			baseDamage = new TypeCollection();
 			baseDamage.kinetic.damageValue = 23;
 			baseDamage.addFlag(DamageFlag.BULLET);
+			this.addFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/NovaPistol.as
+++ b/classes/Items/Guns/NovaPistol.as
@@ -50,6 +50,7 @@ package classes.Items.Guns
 			baseDamage.addFlag(DamageFlag.LASER);
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			this.addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/NovaRifle.as
+++ b/classes/Items/Guns/NovaRifle.as
@@ -49,6 +49,7 @@ package classes.Items.Guns
 			baseDamage.addFlag(DamageFlag.LASER);
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			this.addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/PlasmaPistol.as
+++ b/classes/Items/Guns/PlasmaPistol.as
@@ -49,6 +49,7 @@
 			baseDamage.addFlag(DamageFlag.CHANCE_APPLY_BURN);
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			this.addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/PyriteIndustriesSuperchargedLaserPistol.as
+++ b/classes/Items/Guns/PyriteIndustriesSuperchargedLaserPistol.as
@@ -48,6 +48,7 @@
 			baseDamage.addFlag(DamageFlag.LASER);
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			this.addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/RudimentaryRevolver.as
+++ b/classes/Items/Guns/RudimentaryRevolver.as
@@ -45,6 +45,7 @@
 			
 			baseDamage.kinetic.damageValue = 9;
 			baseDamage.addFlag(DamageFlag.BULLET);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/SalamanderPistol.as
+++ b/classes/Items/Guns/SalamanderPistol.as
@@ -49,6 +49,7 @@
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			baseDamage.addFlag(DamageFlag.LASER);
 			addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/SalamanderRifle.as
+++ b/classes/Items/Guns/SalamanderRifle.as
@@ -49,6 +49,7 @@
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			baseDamage.addFlag(DamageFlag.LASER);
 			addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/SaurmorianRifle.as
+++ b/classes/Items/Guns/SaurmorianRifle.as
@@ -49,6 +49,7 @@ package classes.Items.Guns
 			addFlag(GLOBAL.ITEM_FLAG_POWER_ARMOR);
 			addFlag(GLOBAL.ITEM_FLAG_EFFECT_FLURRYBONUS);
 			baseDamage.addFlag(DamageFlag.NO_CRIT);
+			this.addFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON);
 
 			this.attack = 7;
 			this.critBonus = 0;

--- a/classes/Items/Guns/ScopedPistol.as
+++ b/classes/Items/Guns/ScopedPistol.as
@@ -50,6 +50,7 @@
 			baseDamage.burning.damageValue = 5;
 			baseDamage.addFlag(DamageFlag.LASER);
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/SecureMP.as
+++ b/classes/Items/Guns/SecureMP.as
@@ -46,6 +46,7 @@
 			baseDamage.addFlag(DamageFlag.BULLET);
 			itemFlags = [GLOBAL.ITEM_FLAG_EFFECT_FLURRYBONUS];
 			baseDamage.addFlag(DamageFlag.NO_CRIT);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/SpitterPistol.as
+++ b/classes/Items/Guns/SpitterPistol.as
@@ -44,6 +44,7 @@
 			baseDamage = new TypeCollection();
 			baseDamage.corrosive.damageValue = 8;
 			//baseDamage.addFlag(DamageFlag.BULLET);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/Stormbull.as
+++ b/classes/Items/Guns/Stormbull.as
@@ -46,6 +46,7 @@
 			baseDamage.addFlag(DamageFlag.BULLET);
 			//baseDamage.addFlag(DamageFlag.NO_CRIT);
 			//addFlag(GLOBAL.ITEM_FLAG_EFFECT_FLURRYBONUS);
+			this.addFlag(GLOBAL.ITEM_FLAG_SHOTGUN_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/TeyaalsHeavyPlasmaCaster.as
+++ b/classes/Items/Guns/TeyaalsHeavyPlasmaCaster.as
@@ -49,6 +49,7 @@
 			baseDamage.addFlag(DamageFlag.CHANCE_APPLY_BURN);
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			this.addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/TheShocker.as
+++ b/classes/Items/Guns/TheShocker.as
@@ -46,6 +46,7 @@
 			baseDamage.electric.damageValue = 8;
 			baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			this.addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/TrenchShotgun.as
+++ b/classes/Items/Guns/TrenchShotgun.as
@@ -43,6 +43,7 @@
 			
 			baseDamage.kinetic.damageValue = 14;
 			baseDamage.addFlag(DamageFlag.BULLET);
+			this.addFlag(GLOBAL.ITEM_FLAG_SHOTGUN_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/Vanquisher.as
+++ b/classes/Items/Guns/Vanquisher.as
@@ -44,6 +44,7 @@
 			baseDamage = new TypeCollection();
 			baseDamage.kinetic.damageValue = 28;
 			baseDamage.addFlag(DamageFlag.BULLET);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/VenomPistol.as
+++ b/classes/Items/Guns/VenomPistol.as
@@ -44,6 +44,7 @@
 			baseDamage = new TypeCollection();
 			baseDamage.poison.damageValue = 8;
 			//baseDamage.addFlag(DamageFlag.BULLET);
+			this.addFlag(GLOBAL.ITEM_FLAG_PISTOL_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/ZKRifle.as
+++ b/classes/Items/Guns/ZKRifle.as
@@ -44,6 +44,7 @@
 			baseDamage = new TypeCollection();
 			baseDamage.kinetic.damageValue = 13;
 			baseDamage.addFlag(DamageFlag.BULLET);
+			this.addFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;

--- a/classes/Items/Guns/ZhouLingRifle.as
+++ b/classes/Items/Guns/ZhouLingRifle.as
@@ -47,6 +47,7 @@
 			baseDamage.freezing.damageValue = 10;
 			//baseDamage.addFlag(DamageFlag.ENERGY_WEAPON);
 			//this.addFlag(GLOBAL.ITEM_FLAG_ENERGY_WEAPON);
+			this.addFlag(GLOBAL.ITEM_FLAG_RIFLE_WEAPON);
 			
 			this.defense = 0;
 			this.shieldDefense = 0;


### PR DESCRIPTION
-[char.rangedNoun]
-[char.gunNoun]
-[char.bowNoun]
These output the last word in a weapon's name because that's currently always the type of weapon it is and accounts for the odd "other" category of gun. To be used when the full name of a weapon would be overly much.

-ballsNounIsAre
Uses the ballsNoun parser and then adds either "is" or "are" based on whether the player has one ball or multiple.
-ballsNounSimpleIsAre
Same as above, but uses ballsNounSimple instead of ballsNoun as its basis