### PR TITLE
Fixed collecting panties during KimberQuest making questlog say "Completed"

### DIFF
--- a/includes/events/kimberQuest/roomFunctions.as
+++ b/includes/events/kimberQuest/roomFunctions.as
@@ -95,7 +95,7 @@ public function kimberWormBonus():Boolean
 public function kimberPantiesBonus():Boolean
 {
 	author("Slab Bulkhead");
-	if (flags["KIMBER_QUEST"] != undefined && flags["KIMBER_QUEST"] >= 1) addButton(0, "Search", function ():void
+	if (flags["KIMBER_QUEST"] != undefined && flags["KIMBER_QUEST"] >= 1 && flags["KIMBER_QUEST_GOT_PANTIES"] == undefined) addButton(0, "Search", function ():void
 	{
 		clearMenu();
 		clearOutput();

--- a/includes/events/kimberQuest/roomFunctions.as
+++ b/includes/events/kimberQuest/roomFunctions.as
@@ -95,11 +95,11 @@ public function kimberWormBonus():Boolean
 public function kimberPantiesBonus():Boolean
 {
 	author("Slab Bulkhead");
-	if (flags["KIMBER_QUEST"] != undefined && flags["KIMBER_QUEST"] < 4) addButton(0, "Search", function ():void
+	if (flags["KIMBER_QUEST"] != undefined && flags["KIMBER_QUEST"] >= 1) addButton(0, "Search", function ():void
 	{
 		clearMenu();
 		clearOutput();
-		flags["KIMBER_QUEST"] += 4;
+		flags["KIMBER_QUEST_GOT_PANTIES"] = 1;
 		output("You hold your breath and search through the rotting bodies. Most of what you find is broken armor and torn clothing, a few battered weapons, and a broken Xenogen sample container, but nothing of real value. Then, when you flip over one of the gabilani bodies, you find a battered metal box about the size of your Codex.");
 		output("\n\nThe box looks like the daer worm chewed on it, but it’s still closed and locked. The lock is small enough that a quick hit from your [pc.meleeWeapon] breaks it, and you pop open the box.");
 		output("\n\nInside, you find a handful of credit chits totaling forty-two hundred credits and a small package wrapped in colorful paper. You unwrap the package, and find it contains a single pair of panties made out of some kind of stretchy material, which grows more sheer the farther you stretch it. Judging by how wide gabilani hips can get, it seems like the panties were made for one of them.\n\n");

--- a/includes/gameStats.as
+++ b/includes/gameStats.as
@@ -3254,7 +3254,7 @@ public function displayQuestLog(showID:String = "All"):void
 				if(flags["KIMBER_QUEST"] == 1) output2(", Accepted, Found and defeated daer worm, <i>Return to Kimber!</i>");
 				if(flags["KIMBER_QUEST"] >= 2) output2(", Accepted, Found and defeated daer worm, Reported to Kimber");
 				if(flags["KIMBER_QUEST"] >= 3) output2(", Completed");
-				if(flags["KIMBER_QUEST"] >= 4) output2("\n<b>* Gabilani Panties:</b> Taken");
+				if(flags["KIMBER_QUEST_GOT_PANTIES"] != undefined) output2("\n<b>* Gabilani Panties:</b> Taken");
 				sideCount++;
 			}
 			// Lane's Illegal Activity


### PR DESCRIPTION
Taking the gabilani panties from the daer worm lair would cause the quest log to say "*** Status:** Offered, Accepted, Found and defeated daer worm, Reported to Kimber, Completed" because it would increment the main quest-tracking flag by 4.
Moved the panty-getting to its own flag so that the "KIMBER_QUEST" flag can still track the actual quest. (also made the panty raid require killing the worm, just in case)