### PR TITLE
Added keybindings for paging through multiple pages of tray buttons.

### DIFF
--- a/classes/UIComponents/ButtonTray.as
+++ b/classes/UIComponents/ButtonTray.as
@@ -195,7 +195,7 @@
 			{
 				buttonPage--;
 			}
-			
+			// Why is this check a thing? It just soft-limits usable inventory, should a future expansion add more.
 			if (buttonPage < 1) buttonPage = 1;
 			if (buttonPage > 4) buttonPage = 4;
 			
@@ -203,7 +203,7 @@
 			
 			CheckPages();
 		}
-		
+
 		private function CheckPages():void
 		{
 			var lastButtonIndex:int = 0;
@@ -506,6 +506,27 @@
 		public function getArgForIndex(arg:int):*
 		{
 			return _buttonData[arg].arg;
+		}
+        /**
+         * Publicly callable function to change to next button page, for use by hotkeys
+        */
+		public function buttonPageGoNext():void
+		{
+			if (!(_buttonPageNext).isActive) return;
+			buttonPage++;
+			// I don't agree that this needs to be a thing, but since it's already here I'll follow it.
+			if(buttonPage > 4) buttonPage = 4;
+			resetButtons();
+			CheckPages();
+		}
+		public function buttonPageGoPrev():void
+		{
+			if (!(_buttonPagePrev).isActive) return;
+			buttonPage--;
+			// I don't agree that this needs to be a thing, but since it's already here I'll follow it.
+			if(buttonPage < 1) buttonPage = 1;
+			resetButtons();
+			CheckPages();
 		}
 	}
 

--- a/classes/UIComponents/ButtonTray.as
+++ b/classes/UIComponents/ButtonTray.as
@@ -186,22 +186,14 @@
 		{
 			if (!(e.currentTarget as SquareButton).isActive) return;
 			var forward:Boolean = ((e.currentTarget as SquareButton).name == "buttonPageNext");
-			
 			if (forward)
 			{
-				buttonPage++;
+				buttonPageGoNext();
 			}
 			else
 			{
-				buttonPage--;
+				buttonPageGoPrev();
 			}
-			// Why is this check a thing? It just soft-limits usable inventory, should a future expansion add more.
-			if (buttonPage < 1) buttonPage = 1;
-			if (buttonPage > 4) buttonPage = 4;
-			
-			resetButtons();
-			
-			CheckPages();
 		}
 
 		private function CheckPages():void
@@ -507,9 +499,9 @@
 		{
 			return _buttonData[arg].arg;
 		}
-        /**
-         * Publicly callable function to change to next button page, for use by hotkeys
-        */
+		/**
+		 * Publicly callable function to change to next button page, for use by hotkeys
+		*/
 		public function buttonPageGoNext():void
 		{
 			if (!(_buttonPageNext).isActive) return;

--- a/includes/ControlBindings.as
+++ b/includes/ControlBindings.as
@@ -174,6 +174,19 @@
 		function(inThis:*):Function {
 			return function():void { inThis.prevOutputPage(); };
 		}(this));
+	inputManager.AddBindableControl(
+		"Buttons Previous Page",
+		"Go to previous page of buttons",
+		function(inThis:*):Function {
+			return function():void { inThis.userInterface.buttonTray.buttonPageGoPrev(); };
+
+		}(this));
+    inputManager.AddBindableControl(
+		"Buttons Next Page",
+		"Go to previous page of buttons",
+		function(inThis:*):Function {
+			return function():void { inThis.userInterface.buttonTray.buttonPageGoNext(); };
+		}(this));
 		
 	import classes.Cheats;
 	
@@ -391,6 +404,8 @@
 	inputManager.BindKeyToControl(35, "Scroll To End");        // case 35: this.endButtonScroll()
 	inputManager.BindKeyToControl(54, "Next Page");            // case 54: this.pageNextButtonKeyEvt()
 	inputManager.BindKeyToControl(89, "Previous Page");        // case 89: this.pagePrevButtonKeyEvt()
+	inputManager.BindKeyToControl(190,"Buttons Next Page");    // case 190: this.userInterface.buttonTray.buttonPageGoNext();
+	inputManager.BindKeyToControl(188,"Buttons Previous Page");// case 188: this.userInterface.buttonTray.buttonPageGoPrev();
 	inputManager.BindKeyToControl(80, "Debug Menu");           // case 80: this.userInterface.debugmm();
 
 

--- a/includes/ControlBindings.as
+++ b/includes/ControlBindings.as
@@ -181,7 +181,7 @@
 			return function():void { inThis.userInterface.buttonTray.buttonPageGoPrev(); };
 
 		}(this));
-    inputManager.AddBindableControl(
+	inputManager.AddBindableControl(
 		"Buttons Next Page",
 		"Go to previous page of buttons",
 		function(inThis:*):Function {


### PR DESCRIPTION
There were no hotkeys to navigate between multiple pages of tray buttons. This commit is a fix for that.

Also, I'm not sure why you're limiting it to four pages maximum of tray icons, since it seems rather arbitrary and limiting if inventory is ever increased or the number of on-board waifus is bumped. But I complied while writing my functions.

If you want, feel free to edit this PR to remove the comments, etc..

Currently, this binds to the `,` and `.` keys, since they are next to each other on a QUERTY board, and also have the handy `<` and `>` marks printed on them, which explains their functions. My other choice would be `h` and `j` (ID's 72 and 74), since the navigation keys are to the immediate right of the third row of on-screen buttons.