### PR TITLE
Turning Tricks Bonus & minor text fixes

### DIFF
--- a/includes/newTexas/tenTonGym.as
+++ b/includes/newTexas/tenTonGym.as
@@ -2514,8 +2514,8 @@ public function liftVoyeurism():void
 	output("\n\nHer patience finally snaps and she grabs him by the horns and pulls him down to his knees, pressing his nose into her dripping cunt. <i>“Jeez, just eat me out already!”</i>");
 
 	if(watchedNico) output("\n\nNico");
-	else output("\n\nThe bull tries");
-	output(" and fails to stifle a laugh. <i>“Hah, finally you get to the fun part. Two words would have done it for me. ‘Eat me’”</i> And while he would have most likely gone on teasing her, his words were quickly muffled by her sopping wet cunny as she finally forces herself onto him.");
+	else output("\n\nThe bull");
+	output(" tries and fails to stifle a laugh. <i>“Hah, finally you get to the fun part. Two words would have done it for me. ‘Eat me’”</i> And while he would have most likely gone on teasing her, his words were quickly muffled by her sopping wet cunny as she finally forces herself onto him.");
 
 	output("\n\nAs if by instinct, his tongue immediately starts assaulting her vagina, his intensity quickly going from gently teasing her clit to flat out tongue fucking her. Her mouth silently hangs open, screaming out moans of pleasure that no one will hear. Her grip around the his horns tightens as she gets more and more into it, her eyes shut tight from the sheer pleasure of his tongue. He pays no attention to her cunt liquor drooling down his mouth, chin, and chest -- instead, he is tonguefucking her pussy like it’s the last thing he’ll ever eat. Whatever he doesn’t lap up takes the form of a <i>“milk mustache”</i> which he’ll wear with pride for the few moments before inevitably he goes to wipe or lick it off. But for now, none of that matters, his entire world has condensed into the sight and taste of the woman before him, accompanied by the audio of her now audible moans.");
 	if(pc.isTreated()) 

--- a/includes/tavros/beths.as
+++ b/includes/tavros/beths.as
@@ -1192,6 +1192,8 @@ public function brothelTurnTrixLicensedWhore(service:String = "none"):void
 		if(service != "all") output(" <i>“You’re a good little earner,”</i> she smirks, a small amount of color in her pale cheeks, raising an eyebrow at what you’ve brought in. <i>“Going to have to look into setting you up with a more permanent type of contract, one of these days.”</i>");
 		else output(" <i>“You’re a good little earner,”</i> she goes on, raising an eyebrow at what you’ve brought in. <i>“Admirable lack of standards, too. Going to have to look into setting you up with a more permanent type of contract, one of these days.”</i>");
 		if(pc.statusEffectv1("Turning Tricks Bonus") == 1) output("\n\nYou look back at your codex and notice a bit more than what was split.\n\n<i>“That’s extra for being a productive whore,”</i> she smiles.");
+		// PC only qualifies for bonus, but hasn't actually received it (9999 maybe encourage PC to come back)
+		// else if(pc.hasStatusEffect("Turning Tricks Bonus")) output(" She smiles, <i>“Come back soon, regulars are properly rewarded.”</i>");
 	}
 	
 	if(totalEarnings > 0) output("\n\nYou have been paid " + totalEarnings + " credits for your efforts.");
@@ -3221,6 +3223,8 @@ public function brothelTurnTrixLicensedWhoreTrap(service:String = "none"):void
 		if(service != "all") output(" <i>“You’re a good little earner,”</i> she smirks, a small amount of color in her pale cheeks, raising an eyebrow at what you’ve brought in. <i>“Going to have to look into setting you up with a more permanent type of contract, one of these days.”</i>");
 		else output(" <i>“You’re a good little earner,”</i> she goes on, raising an eyebrow at what you’ve brought in. <i>“Admirable lack of standards, too. Going to have to look into setting you up with a more permanent type of contract, one of these days.”</i>");
 		if(pc.statusEffectv1("Turning Tricks Bonus") == 1) output("\n\nYou look back at your codex and notice a bit more than what was split.\n\n<i>“That’s extra for being a productive whore,”</i> she smiles.");
+		// PC only qualifies for bonus, but hasn't actually received it (9999 maybe encourage PC to come back)
+		// else if(pc.hasStatusEffect("Turning Tricks Bonus")) output(" She smiles, <i>“Come back soon, regulars are properly rewarded.”</i>");
 	}
 	
 	if(totalEarnings > 0) output("\n\nYou have been paid " + totalEarnings + " credits for your efforts.");

--- a/includes/tavros/beths.as
+++ b/includes/tavros/beths.as
@@ -904,12 +904,17 @@ public function brothelWhorePayment(baseAmount:Number = 0, service:String = "non
 	// Bonus for contract workers who whore daily get a 25% bonus
 	if(flags["BETHS_CONTRACT_WHORE"] != undefined)
 	{
+		var bonusTime:int = (1440);
+		// PC returns withing 24h and receives bonus payment, reset Turning Tricks timer
 		if(pc.hasStatusEffect("Turning Tricks Bonus"))
 		{
-			var bonusTime:int = (1440);
 			(returnAmount * 1.25);
+			// Reset timer
 			pc.setStatusMinutes("Turning Tricks Bonus", bonusTime);
+			// Player has received bonus
+			if (pc.statusEffectv1("Turning Tricks Bonus") == 0) pc.setStatusValue("Turning Tricks Bonus", 1, 1);
 		}
+		// PC qualifies for bonus the next time
 		else pc.createStatusEffect("Turning Tricks Bonus", 0, 0, 0, 0, true, "", "", false, bonusTime);
 	}
 	
@@ -1186,7 +1191,7 @@ public function brothelTurnTrixLicensedWhore(service:String = "none"):void
 	{
 		if(service != "all") output(" <i>“You’re a good little earner,”</i> she smirks, a small amount of color in her pale cheeks, raising an eyebrow at what you’ve brought in. <i>“Going to have to look into setting you up with a more permanent type of contract, one of these days.”</i>");
 		else output(" <i>“You’re a good little earner,”</i> she goes on, raising an eyebrow at what you’ve brought in. <i>“Admirable lack of standards, too. Going to have to look into setting you up with a more permanent type of contract, one of these days.”</i>");
-		if(pc.hasStatusEffect("Turning Tricks Bonus")) output("\n\nYou look back at your codex and notice a bit more than what was split.\n\n<i>“That’s extra for being a productive whore,”</i> she smiles.");
+		if(pc.statusEffectv1("Turning Tricks Bonus") == 1) output("\n\nYou look back at your codex and notice a bit more than what was split.\n\n<i>“That’s extra for being a productive whore,”</i> she smiles.");
 	}
 	
 	if(totalEarnings > 0) output("\n\nYou have been paid " + totalEarnings + " credits for your efforts.");
@@ -2596,12 +2601,17 @@ public function brothelWhorePaymentTrap(baseAmount:Number = 0, service:String = 
 	// Bonus for contract workers who whore daily get a 25% bonus
 	if(flags["BETHS_CONTRACT_WHORE"] != undefined)
 	{
+		var bonusTime:int = (1440);
+		// PC returns withing 24h and receives bonus payment, reset Turning Tricks timer
 		if(pc.hasStatusEffect("Turning Tricks Bonus"))
 		{
-			var bonusTime:int = (1440);
 			(returnAmount * 1.25);
+			// Reset timer
 			pc.setStatusMinutes("Turning Tricks Bonus", bonusTime);
+			// Player has received bonus
+			if (pc.statusEffectv1("Turning Tricks Bonus") == 0) pc.setStatusValue("Turning Tricks Bonus", 1, 1);
 		}
+		// PC qualifies for bonus the next time
 		else pc.createStatusEffect("Turning Tricks Bonus", 0, 0, 0, 0, true, "", "", false, bonusTime);
 	}
 	
@@ -3210,7 +3220,7 @@ public function brothelTurnTrixLicensedWhoreTrap(service:String = "none"):void
 	{
 		if(service != "all") output(" <i>“You’re a good little earner,”</i> she smirks, a small amount of color in her pale cheeks, raising an eyebrow at what you’ve brought in. <i>“Going to have to look into setting you up with a more permanent type of contract, one of these days.”</i>");
 		else output(" <i>“You’re a good little earner,”</i> she goes on, raising an eyebrow at what you’ve brought in. <i>“Admirable lack of standards, too. Going to have to look into setting you up with a more permanent type of contract, one of these days.”</i>");
-		if(pc.hasStatusEffect("Turning Tricks Bonus")) output("\n\nYou look back at your codex and notice a bit more than what was split.\n\n<i>“That’s extra for being a productive whore,”</i> she smiles.");
+		if(pc.statusEffectv1("Turning Tricks Bonus") == 1) output("\n\nYou look back at your codex and notice a bit more than what was split.\n\n<i>“That’s extra for being a productive whore,”</i> she smiles.");
 	}
 	
 	if(totalEarnings > 0) output("\n\nYou have been paid " + totalEarnings + " credits for your efforts.");

--- a/includes/tavros/beths.as
+++ b/includes/tavros/beths.as
@@ -1184,8 +1184,8 @@ public function brothelTurnTrixLicensedWhore(service:String = "none"):void
 	}
 	else
 	{
-		if(service != "all") output("<i>“You’re a good little earner,”</i> she smirks, a small amount of color in her pale cheeks, raising an eyebrow at what you’ve brought in. <i>“Going to have to look into setting you up with a more permanent type of contract, one of these days.”</i>");
-		else output("<i>“You’re a good little earner,”</i> she goes on, raising an eyebrow at what you’ve brought in. <i>“Admirable lack of standards, too. Going to have to look into setting you up with a more permanent type of contract, one of these days.”</i>");
+		if(service != "all") output(" <i>“You’re a good little earner,”</i> she smirks, a small amount of color in her pale cheeks, raising an eyebrow at what you’ve brought in. <i>“Going to have to look into setting you up with a more permanent type of contract, one of these days.”</i>");
+		else output(" <i>“You’re a good little earner,”</i> she goes on, raising an eyebrow at what you’ve brought in. <i>“Admirable lack of standards, too. Going to have to look into setting you up with a more permanent type of contract, one of these days.”</i>");
 		if(pc.hasStatusEffect("Turning Tricks Bonus")) output("\n\nYou look back at your codex and notice a bit more than what was split.\n\n<i>“That’s extra for being a productive whore,”</i> she smiles.");
 	}
 	
@@ -3208,8 +3208,8 @@ public function brothelTurnTrixLicensedWhoreTrap(service:String = "none"):void
 	}
 	else
 	{
-		if(service != "all") output("<i>“You’re a good little earner,”</i> she smirks, a small amount of color in her pale cheeks, raising an eyebrow at what you’ve brought in. <i>“Going to have to look into setting you up with a more permanent type of contract, one of these days.”</i>");
-		else output("<i>“You’re a good little earner,”</i> she goes on, raising an eyebrow at what you’ve brought in. <i>“Admirable lack of standards, too. Going to have to look into setting you up with a more permanent type of contract, one of these days.”</i>");
+		if(service != "all") output(" <i>“You’re a good little earner,”</i> she smirks, a small amount of color in her pale cheeks, raising an eyebrow at what you’ve brought in. <i>“Going to have to look into setting you up with a more permanent type of contract, one of these days.”</i>");
+		else output(" <i>“You’re a good little earner,”</i> she goes on, raising an eyebrow at what you’ve brought in. <i>“Admirable lack of standards, too. Going to have to look into setting you up with a more permanent type of contract, one of these days.”</i>");
 		if(pc.hasStatusEffect("Turning Tricks Bonus")) output("\n\nYou look back at your codex and notice a bit more than what was split.\n\n<i>“That’s extra for being a productive whore,”</i> she smiles.");
 	}
 	


### PR DESCRIPTION
The biggest changes here are to Turning Tricks Bonus, in addition some minor text fixes are also included.

Currently the first time _Turning Tricks Bonus_ is set it has an infinite duration.
~Secondly since it is set before the earnings are actually calculated, it means that the first time you whore the bonus is set and afterwards immediatly used in the calculation.~ Actually it is not the earnings that are calculated incorrectly, but the notification to the PC is incorrect. 

The notification comes from this line:
https://github.com/OXOIndustries/TiTS-Public/blob/d831c8805b8af9e0e31d30af20f74d018752b7db/includes/tavros/beths.as#L1189

However _Turning Tricks Bonus_ has already been set at this point by the function call just before it:
https://github.com/OXOIndustries/TiTS-Public/blob/d831c8805b8af9e0e31d30af20f74d018752b7db/includes/tavros/beths.as#L1157

Same holds for the trap variant later on.

~Therefore I introduced a new status _Turning Tricks Bonus Qualify_ which is set the first time and updated to _Turning Tricks Bonus_ in subsequent sessions.~ Therefore I used v1 of _Turning Tricks Bonus_ to reflect whether or not the PC has actually received the bonus.
Finally it might be a good idea to notify the player about the bonus, so I added comments (since I'm not actually a writer) to indicate how and where this could be done. The line can easily be included by uncommenting it.