### PR TITLE
Reduce stage frameRate when window is not focused.

### DIFF
--- a/classes/TiTS.as
+++ b/classes/TiTS.as
@@ -688,6 +688,9 @@
 		// Game data
 		private var _perkDB:Perks;
 		public function get perkDB():Perks { return _perkDB; }
+		
+		private var originalFrameRate:uint = stage.frameRate;
+		private var standbyFrameRate:uint = 8;
 
 		public function TiTS()
 		{
@@ -780,6 +783,9 @@
 			clearMenu();
 
 			addEventListener(Event.FRAME_CONSTRUCTED, finishInit);
+			
+			this.stage.nativeWindow.addEventListener(Event.ACTIVATE, windowActivateHandler);
+			this.stage.nativeWindow.addEventListener(Event.DEACTIVATE, windowDeactivateHandler);
 		}
 		
 		/* Try to safely report errors to the user
@@ -922,6 +928,14 @@
 			}
 			
 			var tw:Tween = new Tween(whatTheFuck, "x", None.easeNone, start, end, 12, false); 
+		}
+		
+		private function windowActivateHandler(e:Event):void {
+			this.stage.frameRate = this.originalFrameRate;
+		}
+		
+		private function windowDeactivateHandler(e:Event):void {
+			this.stage.frameRate = this.standbyFrameRate;
 		}
 		
 		// Proxy clearMenu calls so we can hook them for controlling save-enabled state


### PR DESCRIPTION
Optimized CPU usage by reducing the stage frameRate from 24 to 8 while the main window is in the background. It took TiTS from around 1.2% CPU usage to 0.35% while in background on my machine.

I'm only able to test this with the AIR deployment because I don't have the dev environment setup for anything else. However I don't think there should be any issues on other platforms since the change is pretty much identical to what's mentioned in adobe's documentation.

_I would not recommend going all the way down to 0 or 1 fps because it's possible to send scroll events to a window without it having focus on some platforms_