### PR TITLE
Automatic display of values in Imperial/International system

### DIFF
--- a/classes/GameData/GameOptions.as
+++ b/classes/GameData/GameOptions.as
@@ -29,6 +29,7 @@ package classes.GameData
 			tempHideRoomAndSceneNames = false;
 			seasonalOverridePreferences = { };
 			samePageLog = false;
+			siUnits = false;
 		}
 		
 		public var primaryBustArtist:String = "SHOU";
@@ -77,6 +78,9 @@ package classes.GameData
 		public var overwriteToggle:Boolean;
 		public var authorToggle:Boolean;
 		public var vendorToggle:Boolean;
+
+		// Display lengths, volumes, weight, etc. in the International System of Units
+		public var siUnits:Boolean;
 	}
 
 }

--- a/classes/TiTS.as
+++ b/classes/TiTS.as
@@ -96,6 +96,8 @@
 	
 	import flash.display.StageScaleMode;
 
+	import classes.Units.UnitSystem;
+
 	//Build the bottom drawer
 	public class TiTS extends MovieClip
 	{		

--- a/classes/UIComponents/ContentModules/OptionsModule.as
+++ b/classes/UIComponents/ContentModules/OptionsModule.as
@@ -82,6 +82,8 @@ package classes.UIComponents.ContentModules
 			addMultiToggleControl("Toggle whether log events get their own page.", "Same Page", "samePageLog", null, null);
 			
 			addMultiToggleControl("Basic character image settings.", "Busts", "bustsEnabled", "Fallback", "bustFallbacks");
+
+			addMultiToggleControl("Toggle International System of Units.", "SI Units", "siUnits", null, null);
 			
 			var bustControl:DoubleSelectControl = new DoubleSelectControl();
 			_controls.push(bustControl);

--- a/classes/Units/UnitSystem.as
+++ b/classes/Units/UnitSystem.as
@@ -2,11 +2,17 @@ package classes.Units
 {
 	import classes.kGAMECLASS;
 	import classes.Engine.Utility.formatFloat;
+	import classes.Engine.Utility.num2Text;
 
 	public class UnitSystem
 	{
 
 		private static const INCH_TO_METER:Number = 0.0254;
+		private static const FOOT_TO_METER:Number = 0.3048;
+
+		private static const INCHES_IN_A_FOOT:int = 12;
+
+		private static const FOOT_TO_METER_APROX:Number = formatFloat(FOOT_TO_METER, 1);
 
 		private static const SI_PREFIX_TERA_POWER:int = 12;
 		private static const SI_PREFIX_GIGA_POWER:int = 9;
@@ -33,20 +39,73 @@ package classes.Units
 			return isSI() ? "centimeters" : "inches";
 		}
 
+		public static function aFoot():String {
+			return isSI() ? "30 centimeters" : "a foot";
+		}
+
+		public static function halfAFoot():String {
+			return isSI() ? "15 centimeters" : "half a foot";
+		}
+
 		public static function lengthInInches(inches:Number, sig:int = 1):Number {
 			return formatFloat((isSI() ? inches * INCH_TO_METER / SI_PREFIX_CENTI_FACTOR : inches), sig);
 		}
 
-		public static function displayHeightInInches(inches:Number):String {
-			var sig:uint = isSI() ? 0 : 1;
+		public static function lengthInFeet(feet:Number, sig:int = 1):Number {
+			return formatFloat((isSI() ? feet * FOOT_TO_METER / SI_PREFIX_CENTI_FACTOR : feet), sig);
+		}
+
+
+		private static function _displayInches(inches:Number, impSig:int = 1, siSig:int = 1, useNum2Text:Boolean = false):String {
+			var sig:uint = isSI() ? siSig : impSig;
 			var value:Number = lengthInInches(inches, sig);
 			var symbol:String = " " + (isSI() ? "centimeter" : "inch");
 			if (!(value == 1 || value == 0)) symbol += isSI() ? "s" : "es";
 
-			return value + symbol;
+			return (useNum2Text ? num2Text(value) : value) + symbol;
 		}
 
-		private static function _lengthInInchesShort(inches:Number, impUnit:String, siUnit:String, impSig:int = 1, siSig:int = 0):String {
+		public static function displayHeightInInches(inches:Number):String {
+			return _displayInches(inches, 1, 0);
+		}
+
+		public static function displayHeight(inches:Number, impStrSep:String = ""):String {
+			var value:Number = lengthInInches(inches, 0);
+			var result:String;
+			if (isSI()) {
+				if (value < 1 / SI_PREFIX_CENTI_FACTOR) {
+					result = value + " centimeter" + (value > 1 ? "s" : "");
+				} else {
+					var meter:Number = value / (1/SI_PREFIX_CENTI_FACTOR);
+					result = meter + " meter" + (meter > 1 ? "s" : "");
+				}
+			} else {
+				var inch:int = value % INCHES_IN_A_FOOT;
+				var feet:int = (value - inch) / INCHES_IN_A_FOOT;
+
+				result = (feet == 0 && inch > 0 ? "" : feet + " f" + (feet > 1 ? "ee" : "oo") + "t") + (inch > 0 ? " " + (impStrSep.length > 0 ? impStrSep + " " : "") + inch + " inch" + (inch > 1 ? "es" : "") : "");
+			}
+			return result;
+		}
+
+		public static function displayInches(inches:Number):String {
+			return _displayInches(inches);
+		}
+
+		public static function displayInchesTextually(inches:Number, sig:uint = 1):String {
+			return _displayInches(inches, sig, sig, true);
+		}
+
+		public static function inchesEstimate(inches:Number):String {
+			return _displayInches(inches, 0, 0);
+		}
+
+		public static function inchesEstimateTextual(inches:Number):String {
+			return _displayInches(inches, 0, 0, true);
+		}
+
+
+		private static function _displayInchesShort(inches:Number, impUnit:String, siUnit:String, impSig:int = 1, siSig:int = 0):String {
 			var sig:uint = isSI() ? siSig : impSig;
 			var value:Number = lengthInInches(inches, sig);
 			var symbol:String = " " + (isSI() ? siUnit : impUnit);
@@ -55,20 +114,21 @@ package classes.Units
 		}
 
 		public static function displayHeightInInchesShort(inches:Number):String {
-			return _lengthInInchesShort(inches, "in", "cm");
+			return _displayInchesShort(inches, "in", "cm");
 		}
 
 		public static function displayHeightInInchesShort2(inches:Number):String {
-			return _lengthInInchesShort(inches, "\"", "cm");
+			return _displayInchesShort(inches, "\"", "cm");
 		}
 
-		public static function displayLengthInInchesShort(inches:Number):String {
-			return _lengthInInchesShort(inches, "in", "cm", 1, 1);
+		public static function displayInchesShort(inches:Number):String {
+			return _displayInchesShort(inches, "in", "cm", 1, 1);
 		}
 
-		public static function displayLengthInInchesShort2(inches:Number):String {
-			return _lengthInInchesShort(inches, "\"", "cm", 1, 1);
+		public static function displayInchesShort2(inches:Number):String {
+			return _displayInchesShort(inches, "\"", "cm", 1, 1);
 		}
+
 
 		public static function centimeterToInch(centimeters:Number):Number {
 			return formatFloat(centimeters / INCH_TO_METER * SI_PREFIX_CENTI_FACTOR, 1);
@@ -76,6 +136,58 @@ package classes.Units
 
 		public static function inchToCentimeter(inches:Number):Number {
 			return formatFloat(inches * INCH_TO_METER / SI_PREFIX_CENTI_FACTOR, 1);
+		}
+
+
+		private static function _displayInchWithHyphen(inches:Number, symbol:String, useNum2Text:Boolean = false, sig:int = 1):String {
+			var value:Number = lengthInInches(inches, sig);
+			return (useNum2Text ? num2Text(value) : value) + "-" + symbol;
+		}
+
+		// Occurence of "-inch"(~280 times) and "-inches"(~13 times) were both found in the codes, but it isn't clear which one should be preferable used.
+		// For now this difference is implemented with this two sets of methods.
+		public static function displayInchWithHyphen(inches:Number, useNum2Text:Boolean = false, sig:int = 1):String {
+			return _displayInchWithHyphen(inches, literalInch(), useNum2Text, sig);
+		}
+
+		public static function displayInchWithHyphenTextually(inches:Number, sig:int = 1):String {
+			return displayInchWithHyphen(inches, true, sig);
+		}
+
+		public static function displayInchesWithHyphen(inches:Number, useNum2Text:Boolean = false, sig:int = 1):String {
+			return _displayInchWithHyphen(inches, literalInches(), useNum2Text, sig);
+		}
+
+		public static function displayInchesWithHyphenTextually(inches:Number, sig:int = 1):String {
+			return displayInchesWithHyphen(inches, true, sig);
+		}
+
+
+		private static function _feetToCentimeterAproximation(feet:Number, sig:int = 1):Number {
+			return formatFloat((isSI() ? feet * FOOT_TO_METER_APROX / SI_PREFIX_CENTI_FACTOR : feet), sig);
+			}
+
+		private static function _feetEstimate(feet:Number, impSig:int = 1, siSig:int = 1, useNum2Text:Boolean = false):String {
+			var sig:uint = isSI() ? siSig : impSig;
+			var value:Number = _feetToCentimeterAproximation(feet, sig);
+			var symbol:String = " ";
+			if (isSI()) {
+				// If the value is inferior to 100, display it in centimeters
+				if (value <  1 / SI_PREFIX_CENTI_FACTOR) {
+					 symbol += "centi";
+					} else value = formatFloat(value * SI_PREFIX_CENTI_FACTOR, siSig);
+					symbol += "meter" + (!(value == 1 || value == 0) ? "s" : "");
+			} else symbol += "f" + (!(value == 1 || value == 0) ? "ee" : "oo") + "t";
+
+			return (useNum2Text ? num2Text(value) : value) + symbol;
+		}
+
+		public static function feetEstimate(feet:Number):String {
+			return _feetEstimate(feet);
+		}
+
+		public static function feetEstimateTextual(feet:Number, sig:uint = 1):String {
+			return _feetEstimate(feet, sig, sig, true);
 		}
 	}
 }

--- a/classes/Units/UnitSystem.as
+++ b/classes/Units/UnitSystem.as
@@ -1,0 +1,81 @@
+package classes.Units
+{
+	import classes.kGAMECLASS;
+	import classes.Engine.Utility.formatFloat;
+
+	public class UnitSystem
+	{
+
+		private static const INCH_TO_METER:Number = 0.0254;
+
+		private static const SI_PREFIX_TERA_POWER:int = 12;
+		private static const SI_PREFIX_GIGA_POWER:int = 9;
+		private static const SI_PREFIX_MEGA_POWER:int = 6;
+		private static const SI_PREFIX_KILO_POWER:int = 3;
+		private static const SI_PREFIX_NONE_POWER:int = 0;
+		private static const SI_PREFIX_CENTI_POWER:int = -2;
+		private static const SI_PREFIX_MILLI_POWER:int = -3;
+		private static const SI_PREFIX_MICRO_POWER:int = -6;
+		private static const SI_PREFIX_NANO_POWER:int = -9;
+		private static const SI_PREFIX_PICO_POWER:int = -12;
+
+		private static const SI_PREFIX_CENTI_FACTOR:Number = Math.pow(10, SI_PREFIX_CENTI_POWER);
+
+		public static function isSI():Boolean {
+			return kGAMECLASS.gameOptions.siUnits;
+		}
+
+		public static function literalInch():String {
+			return isSI() ? "centimeter" : "inch";
+		}
+
+		public static function literalInches():String {
+			return isSI() ? "centimeters" : "inches";
+		}
+
+		public static function lengthInInches(inches:Number, sig:int = 1):Number {
+			return formatFloat((isSI() ? inches * INCH_TO_METER / SI_PREFIX_CENTI_FACTOR : inches), sig);
+		}
+
+		public static function displayHeightInInches(inches:Number):String {
+			var sig:uint = isSI() ? 0 : 1;
+			var value:Number = lengthInInches(inches, sig);
+			var symbol:String = " " + (isSI() ? "centimeter" : "inch");
+			if (!(value == 1 || value == 0)) symbol += isSI() ? "s" : "es";
+
+			return value + symbol;
+		}
+
+		private static function _lengthInInchesShort(inches:Number, impUnit:String, siUnit:String, impSig:int = 1, siSig:int = 0):String {
+			var sig:uint = isSI() ? siSig : impSig;
+			var value:Number = lengthInInches(inches, sig);
+			var symbol:String = " " + (isSI() ? siUnit : impUnit);
+
+			return value + symbol;
+		}
+
+		public static function displayHeightInInchesShort(inches:Number):String {
+			return _lengthInInchesShort(inches, "in", "cm");
+		}
+
+		public static function displayHeightInInchesShort2(inches:Number):String {
+			return _lengthInInchesShort(inches, "\"", "cm");
+		}
+
+		public static function displayLengthInInchesShort(inches:Number):String {
+			return _lengthInInchesShort(inches, "in", "cm", 1, 1);
+		}
+
+		public static function displayLengthInInchesShort2(inches:Number):String {
+			return _lengthInInchesShort(inches, "\"", "cm", 1, 1);
+		}
+
+		public static function centimeterToInch(centimeters:Number):Number {
+			return formatFloat(centimeters / INCH_TO_METER * SI_PREFIX_CENTI_FACTOR, 1);
+		}
+
+		public static function inchToCentimeter(inches:Number):Number {
+			return formatFloat(inches * INCH_TO_METER / SI_PREFIX_CENTI_FACTOR, 1);
+		}
+	}
+}

--- a/classes/Units/UnitSystem.as
+++ b/classes/Units/UnitSystem.as
@@ -4,11 +4,17 @@ package classes.Units
 	import classes.Engine.Utility.formatFloat;
 	import classes.Engine.Utility.num2Text;
 
+	/**
+	 * Display automatically values in the correct unit system; Imperial or International (SI).
+	 * @author Phillip Daisy Seventh
+	 */
 	public class UnitSystem
 	{
 
 		private static const INCH_TO_METER:Number = 0.0254;
 		private static const FOOT_TO_METER:Number = 0.3048;
+
+		private static const POUND_TO_GRAM:Number = 453.59237;
 
 		private static const INCHES_IN_A_FOOT:int = 12;
 
@@ -18,18 +24,61 @@ package classes.Units
 		private static const SI_PREFIX_GIGA_POWER:int = 9;
 		private static const SI_PREFIX_MEGA_POWER:int = 6;
 		private static const SI_PREFIX_KILO_POWER:int = 3;
+		private static const SI_PREFIX_HECTO_POWER:int = 2;
+		private static const SI_PREFIX_DECA_POWER:int = 1;
 		private static const SI_PREFIX_NONE_POWER:int = 0;
+		private static const SI_PREFIX_DECI_POWER:int = -1;
 		private static const SI_PREFIX_CENTI_POWER:int = -2;
 		private static const SI_PREFIX_MILLI_POWER:int = -3;
 		private static const SI_PREFIX_MICRO_POWER:int = -6;
 		private static const SI_PREFIX_NANO_POWER:int = -9;
 		private static const SI_PREFIX_PICO_POWER:int = -12;
 
+		private static const SI_MAX_PREFIX_POWER:int = SI_PREFIX_TERA_POWER;
+		private static const SI_MIN_PREFIX_POWER:int = SI_PREFIX_PICO_POWER;
+
+		private static const SI_PREFIX_FACTOR:int = 1000;
+		private static const SI_PREFIX_POWER_STEP:int = 3;
+
 		private static const SI_PREFIX_CENTI_FACTOR:Number = Math.pow(10, SI_PREFIX_CENTI_POWER);
+
+		private static const SI_POWER_TO_PREFIX:Object = {}
+		SI_POWER_TO_PREFIX[SI_PREFIX_TERA_POWER.toString()] = { name: "tera", symbol: "T" };
+		SI_POWER_TO_PREFIX[SI_PREFIX_GIGA_POWER.toString()] = { name: "giga", symbol: "G" };
+		SI_POWER_TO_PREFIX[SI_PREFIX_MEGA_POWER.toString()] = { name: "mega", symbol: "M" };
+		SI_POWER_TO_PREFIX[SI_PREFIX_KILO_POWER.toString()] = { name: "kilo", symbol: "k" };
+		SI_POWER_TO_PREFIX[SI_PREFIX_HECTO_POWER.toString()] = { name: "hecto", symbol: "h" };
+		SI_POWER_TO_PREFIX[SI_PREFIX_DECA_POWER.toString()] = { name: "deca", symbol: "da" };
+		SI_POWER_TO_PREFIX[SI_PREFIX_NONE_POWER.toString()] = { name: "", symbol: "" };
+		SI_POWER_TO_PREFIX[SI_PREFIX_DECI_POWER.toString()] = { name: "deci", symbol: "d" };
+		SI_POWER_TO_PREFIX[SI_PREFIX_CENTI_POWER.toString()] = { name: "centi", symbol: "c" };
+		SI_POWER_TO_PREFIX[SI_PREFIX_MILLI_POWER.toString()] = { name: "milli", symbol: "m" };
+		SI_POWER_TO_PREFIX[SI_PREFIX_MICRO_POWER.toString()] = { name: "micro", symbol: "µ" };
+		SI_POWER_TO_PREFIX[SI_PREFIX_NANO_POWER.toString()] = { name: "nano", symbol: "n" };
+		SI_POWER_TO_PREFIX[SI_PREFIX_PICO_POWER.toString()] = { name: "pico", symbol: "p" };
+
+		private static function _optimizePrefix(value:Number, minPrefixPower:int = SI_MIN_PREFIX_POWER, maxPrefixPower:int = SI_MAX_PREFIX_POWER, factor:int = SI_PREFIX_FACTOR):Object {
+			function r(value:Number, power:int):Object {
+				if (value == 0) {
+					return {value: 0, power: 0};
+				} else if (value >= factor && power < maxPrefixPower) {
+					return r(value / factor, power + SI_PREFIX_POWER_STEP);
+				} else if (value < 1 && power > minPrefixPower) {
+					return r(value * factor, power - SI_PREFIX_POWER_STEP);
+				} else {
+					return {value: value, power: power}
+				}
+			}
+			return r(value, 0);
+		}
 
 		public static function isSI():Boolean {
 			return kGAMECLASS.gameOptions.siUnits;
 		}
+
+		// = LENGTH ===================================================================================
+
+		// - For using units in a text ----------
 
 		public static function literalInch():String {
 			return isSI() ? "centimeter" : "inch";
@@ -47,6 +96,8 @@ package classes.Units
 			return isSI() ? "15 centimeters" : "half a foot";
 		}
 
+		// - For converting length from a system to another -
+
 		public static function lengthInInches(inches:Number, sig:int = 1):Number {
 			return formatFloat((isSI() ? inches * INCH_TO_METER / SI_PREFIX_CENTI_FACTOR : inches), sig);
 		}
@@ -55,6 +106,15 @@ package classes.Units
 			return formatFloat((isSI() ? feet * FOOT_TO_METER / SI_PREFIX_CENTI_FACTOR : feet), sig);
 		}
 
+		public static function centimeterToInch(centimeters:Number):Number {
+			return formatFloat(centimeters / INCH_TO_METER * SI_PREFIX_CENTI_FACTOR, 1);
+		}
+
+		public static function inchToCentimeter(inches:Number):Number {
+			return formatFloat(inches * INCH_TO_METER / SI_PREFIX_CENTI_FACTOR, 1);
+		}
+
+		// - For printing length in inches ----------
 
 		private static function _displayInches(inches:Number, impSig:int = 1, siSig:int = 1, useNum2Text:Boolean = false):String {
 			var sig:uint = isSI() ? siSig : impSig;
@@ -88,6 +148,58 @@ package classes.Units
 			return result;
 		}
 
+		public static function displayPreciseLengthShort2(inches:Number):String {
+			var value:Number = lengthInInches(inches, 3);
+			var result:String;
+			if (isSI()) {
+				if (value < 1 / SI_PREFIX_CENTI_FACTOR) {
+					result = value + " cm";
+				} else {
+					var meter:Number = formatFloat(value / (1/SI_PREFIX_CENTI_FACTOR), 3);
+					result = meter + " m";
+				}
+			} else {
+				// Feet
+				var feet:int = Math.floor(value / INCHES_IN_A_FOOT);
+				// Inches
+				var inch:int = Math.floor(value % INCHES_IN_A_FOOT);
+				var num:String = "";
+				var den:String = "";
+				if(value % INCHES_IN_A_FOOT > 0)
+				{
+					// Fractional stuff, proper maffs format! (to the nearest 1/16th inch)
+					var fraction:Number = formatFloat((value - Math.floor(value)), 4);
+					if(fraction >= 0.0125)
+					{
+						if(fraction <= 0.0625) { num = "1"; den = "16"; }
+						else if(fraction <= 0.125) { num = "1"; den = "8"; }
+						else if(fraction <= 0.1875) { num = "3"; den = "16"; }
+						else if(fraction <= 0.25) { num = "1"; den = "4"; }
+						else if(fraction <= 0.3125) { num = "5"; den = "16"; }
+						else if(fraction <= 0.375) { num = "3"; den = "8"; }
+						else if(fraction <= 0.4375) { num = "7"; den = "16"; }
+						else if(fraction <= 0.5) { num = "1"; den = "2"; }
+						else if(fraction <= 0.5625) { num = "9"; den = "16"; }
+						else if(fraction <= 0.625) { num = "5"; den = "8"; }
+						else if(fraction <= 0.6875) { num = "11"; den = "16"; }
+						else if(fraction <= 0.75) { num = "3"; den = "4"; }
+						else if(fraction <= 0.8125) { num = "13"; den = "16"; }
+						else if(fraction <= 0.875) { num = "7"; den = "8"; }
+						else if(fraction <= 0.9375) { num = "15"; den = "16"; }
+						else {
+							inch++;
+							if(inch == INCHES_IN_A_FOOT) { feet++; inch = 0; }
+						}
+					}
+				}
+				result = (feet == 0 && (inch > 0 || num != "") ? "" : feet + "'")
+					+ (inch > 0 ? (feet > 0 ? " " : "") + inch : "")
+					+ (num != "" ? (feet > 0 || inch > 0 ? " " : "") + "<sup>" + num + "</sup>/<sub>" + den + "</sub>" : "")
+					+ (inch > 0 || num != "" ? "\"" : "");
+			}
+			return result;
+		}
+
 		public static function displayInches(inches:Number):String {
 			return _displayInches(inches);
 		}
@@ -104,6 +216,7 @@ package classes.Units
 			return _displayInches(inches, 0, 0, true);
 		}
 
+		// - For printing length in inches with the unit written as a symbol -
 
 		private static function _displayInchesShort(inches:Number, impUnit:String, siUnit:String, impSig:int = 1, siSig:int = 0):String {
 			var sig:uint = isSI() ? siSig : impSig;
@@ -129,15 +242,7 @@ package classes.Units
 			return _displayInchesShort(inches, "\"", "cm", 1, 1);
 		}
 
-
-		public static function centimeterToInch(centimeters:Number):Number {
-			return formatFloat(centimeters / INCH_TO_METER * SI_PREFIX_CENTI_FACTOR, 1);
-		}
-
-		public static function inchToCentimeter(inches:Number):Number {
-			return formatFloat(inches * INCH_TO_METER / SI_PREFIX_CENTI_FACTOR, 1);
-		}
-
+		// - For printing length in inches with a hyphen between the value and the unit -
 
 		private static function _displayInchWithHyphen(inches:Number, symbol:String, useNum2Text:Boolean = false, sig:int = 1):String {
 			var value:Number = lengthInInches(inches, sig);
@@ -162,10 +267,11 @@ package classes.Units
 			return displayInchesWithHyphen(inches, true, sig);
 		}
 
+		// - For printing approximation of length in feet -
 
 		private static function _feetToCentimeterAproximation(feet:Number, sig:int = 1):Number {
 			return formatFloat((isSI() ? feet * FOOT_TO_METER_APROX / SI_PREFIX_CENTI_FACTOR : feet), sig);
-			}
+		}
 
 		private static function _feetEstimate(feet:Number, impSig:int = 1, siSig:int = 1, useNum2Text:Boolean = false):String {
 			var sig:uint = isSI() ? siSig : impSig;
@@ -189,5 +295,70 @@ package classes.Units
 		public static function feetEstimateTextual(feet:Number, sig:uint = 1):String {
 			return _feetEstimate(feet, sig, sig, true);
 		}
+
+		// = LENGTH - END =============================================================================
+
+
+		// = WEIGHT ===================================================================================
+
+		private static function _weightInPounds(pounds:Number):Number {
+			return isSI() ? pounds * POUND_TO_GRAM : pounds;
+		}
+
+		public static function displayWeightShort(pounds:Number):String {
+			var value:Number = _weightInPounds(pounds);
+			var result:String;
+			if (isSI()) {
+				// A power two steps higher than the max can be used, because how the prefix goes two steps down from a megagram to a tonne
+				var optValue:Object = _optimizePrefix(value, SI_PREFIX_MILLI_POWER, SI_MAX_PREFIX_POWER + SI_PREFIX_POWER_STEP * 2);
+				var unit:String = "g";
+				// A megagram [Mg] is a tonne [t]
+				if (optValue.power > SI_PREFIX_KILO_POWER) { unit = "t"; optValue.power -= SI_PREFIX_POWER_STEP * 2; }
+				result = formatFloat(optValue.value, 3) + " " + SI_POWER_TO_PREFIX[optValue.power.toString()].symbol + unit;
+			} else result = formatFloat(value, 3) + " lb";
+			return result;
+		}
+
+		// = WEIGHT - END =============================================================================
+
+		// = VOLUME ===================================================================================
+
+		// - Liquid volumes -------------------------
+
+		public static function displayLitersShort(milliliters:Number):String {
+			var optValue:Object = _optimizePrefix(milliliters / SI_PREFIX_FACTOR);
+			return formatFloat(optValue.value, 3) + " " + SI_POWER_TO_PREFIX[optValue.power.toString()].symbol + (isSI() ? "l" : "L");
+		}
+
+		// - Solid volumes --------------------------
+
+		private static function _volumeInCubicInches(cubicinches:Number, sig:int = 3):Number {
+			return isSI() ? cubicinches * Math.pow(INCH_TO_METER, 3) : cubicinches;
+		}
+
+		public static function displayVolumeShort(cubicinches:Number):String {
+			var value:Number = _volumeInCubicInches(cubicinches);
+			var result:String;
+			if (isSI()) {
+				var optValue:Object = _optimizePrefix(value, SI_PREFIX_MILLI_POWER, SI_PREFIX_KILO_POWER, Math.pow(SI_PREFIX_FACTOR, 3));
+				if (optValue.power == SI_PREFIX_MILLI_POWER) {
+					const DECI_IN_MILLI:int = 1000000;
+					const CENTI_IN_MILLI:int = 1000;
+					if (optValue.value >= DECI_IN_MILLI) { optValue.value /= DECI_IN_MILLI; optValue.power = SI_PREFIX_DECI_POWER; }
+					else if (optValue.value >= CENTI_IN_MILLI) { optValue.value /= CENTI_IN_MILLI; optValue.power = SI_PREFIX_CENTI_POWER; }
+				} else if (optValue.power == SI_PREFIX_NONE_POWER) {
+					const HECTO_IN_METER:int = 1000000;
+					const DECA_IN_METER:int = 1000;
+					if (optValue.value >= HECTO_IN_METER) { optValue.value /= HECTO_IN_METER; optValue.power = SI_PREFIX_HECTO_POWER; }
+					else if (optValue.value >= DECA_IN_METER) { optValue.value /= DECA_IN_METER; optValue.power = SI_PREFIX_DECA_POWER; }
+				}
+				result = formatFloat(optValue.value, 3) + " " + SI_POWER_TO_PREFIX[optValue.power.toString()].symbol + "m³";
+			} else {
+				result = formatFloat(value, 3) + " " + "in³";
+			}
+			return result;
+		}
+
+		// = VOLUME - END =============================================================================
 	}
 }

--- a/includes/appearance.as
+++ b/includes/appearance.as
@@ -1,4 +1,4 @@
-﻿import classes.Characters.PlayerCharacter;
+import classes.Characters.PlayerCharacter;
 import classes.Creature;
 import classes.StorageClass;
 import classes.GameData.Pregnancy.PregnancyManager;
@@ -159,10 +159,8 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 	{
 		outputRouter((target == pc ? "You":"[target.HeShe]") + " started your journey as " + indefiniteArticle(target.originalRace) + ", but " + (target == pc ? "you’ve":"[target.heShe] has") + " become "+indefiniteArticle(target.race())+" over the course of " + (target == pc ? "your":"[target.hisHer]") + " adventures.");
 	}
-	outputRouter(" " + (target == pc ? "You’re":"[target.HeShe] is") + " a good " + Math.floor(target.tallness / 12) + " feet");
-	if(target.tallness % 12 != 0) outputRouter(" and " + Math.round(target.tallness % 12) + " inches");
-	outputRouter(" tall by ancient imperial measurements and " + Math.round(target.tallness * 0.0254 * 100)/100 + " meters in the more accepted metric system.");
-	
+	outputRouter(" " + (target == pc ? "You’re":"[target.HeShe] is") + " a good " + UnitSystem.displayHeight(target.tallness, "and") + " tall " + (UnitSystem.isSI() ? "in the widely accepted metric system" : "by ancient imperial measurements") + ".");
+
 	var isNude:Boolean = (target.isNude());
 	var showTits:Boolean = (target.isChestVisible() && target.hasBreasts());
 	var showCrotch:Boolean = (target.isCrotchVisible());
@@ -301,7 +299,7 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 			outputRouter((target == pc ? "You have":"[target.Name] has") + " a tapered, shrewd-looking vulpine face with a speckling of downward-curved whiskers just behind the nose.");
 			if(target.skinType == GLOBAL.SKIN_TYPE_SKIN && !target.hasFaceFlag(GLOBAL.FLAG_FURRED)) outputRouter(" Oddly enough, there’s no fur on " + (target == pc ? "your":"[target.hisHer]") + " animalistic muzzle, just " + faceFurScales + "."); 
 			else if(target.skinType == GLOBAL.SKIN_TYPE_FUR || target.hasFaceFlag(GLOBAL.FLAG_FURRED)) outputRouter(" A coat of " + faceFurScales + " decorates " + (target == pc ? "your":"[target.hisHer]") + " muzzle.");
-			else if(target.skinType == GLOBAL.SKIN_TYPE_SCALES || target.hasFaceFlag(GLOBAL.FLAG_SCALED)) outputRouter(" Strangely, " + faceFurScales + " adorn every inch of " + (target == pc ? "your":"[target.hisHer]") + " animalistic visage.");
+			else if(target.skinType == GLOBAL.SKIN_TYPE_SCALES || target.hasFaceFlag(GLOBAL.FLAG_SCALED)) outputRouter(" Strangely, " + faceFurScales + " adorn every " + UnitSystem.literalInch() + " of " + (target == pc ? "your":"[target.hisHer]") + " animalistic visage.");
 			break;
 		case GLOBAL.TYPE_MOUSEMAN:
 			outputRouter((target == pc ? "Your":"[target.Name]’s") + " face is generally human in shape and structure, with " + target.skin(true,true,true));
@@ -757,7 +755,7 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 				outputRouter(" A pair of sheep-like ears flop cutely down the sides of " + (target == pc ? "your":"[target.hisHer]") + " " + headNoun + ".");
 				break;
 			case GLOBAL.TYPE_GOAT:
-				outputRouter(" A pair of " + num2Text(target.earLength) + "-inch long, flicking goat ears protrude from the sides of " + (target == pc ? "your":"[target.hisHer]") + " " + headNoun);
+				outputRouter(" A pair of " + UnitSystem.displayInchWithHyphenTextually(target.earLength, 0) + " long, flicking goat ears protrude from the sides of " + (target == pc ? "your":"[target.hisHer]") + " " + headNoun);
 				if(!nonFurrySkin) outputRouter(" with tufts of fur on their backs");
 				outputRouter(".");
 				break;
@@ -804,10 +802,10 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 					if(target.earType == GLOBAL.TYPE_QUAD_LAPINE) outputRouter(" Two pairs of");
 					else outputRouter(" A pair of");
 					outputRouter(" alert rabbit ears stick up");
-					if(target.earLength >= target.tallness/2) outputRouter(" partway before their " + num2Text(target.earLength) + "-inch length drags them downward under their own weight.");
+					if(target.earLength >= target.tallness/2) outputRouter(" partway before their " + UnitSystem.displayInchWithHyphenTextually(target.earLength, 0) + " length drags them downward under their own weight.");
 					else
 					{
-						if(target.earLength > 1) outputRouter(" " + num2Text(target.earLength) + " inches");
+						if(target.earLength > 1) outputRouter(" " + UnitSystem.displayInchesTextually(target.earLength, 0));
 						outputRouter(" from the top of " + (target == pc ? "your":"[target.hisHer]") + " " + headNoun + ",");
 						if(target.earLength > target.tallness) outputRouter(" dragging on the floor");
 						else if(target.earLength > target.tallness/2) outputRouter(" swaying about");
@@ -859,7 +857,7 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 				break;
 			case GLOBAL.TYPE_RASKVEL:
 				outputRouter(" A pair of");
-				if(target.earLength >= (target.tallness * 0.6)) outputRouter(" " + num2Text(target.earLength) + "-inch");
+				if(target.earLength >= (target.tallness * 0.6)) outputRouter(" " + UnitSystem.displayInchWithHyphenTextually(target.earLength, 0));
 				outputRouter(" long raskvel ears dangle from " + (target == pc ? "your":"[target.hisHer]") + " " + headNoun + " down past " + (target == pc ? "your":"[target.hisHer]") + " waist.");
 				break;
 			case GLOBAL.TYPE_SYLVAN:
@@ -870,22 +868,22 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 				//2-4 inches: 
 				else if(target.earLength <= 4)
 				{
-					outputRouter(" A pair of triangular, elven ears protrude from the sides of " + (target == pc ? "your":"[target.hisHer]") + " " + headNoun + ", sticking out a full " + num2Text(target.earLength) + " inches from the sides of " + (target == pc ? "your":"[target.hisHer]") + " head. Small extra muscles let them twitch or droop expressively.");
+					outputRouter(" A pair of triangular, elven ears protrude from the sides of " + (target == pc ? "your":"[target.hisHer]") + " " + headNoun + ", sticking out a full " + UnitSystem.displayInchesTextually(target.earLength, 0) + " from the sides of " + (target == pc ? "your":"[target.hisHer]") + " head. Small extra muscles let them twitch or droop expressively.");
 				}
 				//5+ inches:
 				else
 				{
-					outputRouter(" A pair of exquisitely long, elf-like ears extend a full " + num2Text(target.earLength) + " inches from the sides of " + (target == pc ? "your":"[target.hisHer]") + " head, triangular in shape with a bit of downward curve along their length. A thought is all it takes for them to change their angle to suit " + (target == pc ? "your":"[target.hisHer]") + " expression, letting even the most rugged face pull off a cutesy pout with ease.");
+					outputRouter(" A pair of exquisitely long, elf-like ears extend a full " + UnitSystem.displayInchesTextually(target.earLength, 0) + " from the sides of " + (target == pc ? "your":"[target.hisHer]") + " head, triangular in shape with a bit of downward curve along their length. A thought is all it takes for them to change their angle to suit " + (target == pc ? "your":"[target.hisHer]") + " expression, letting even the most rugged face pull off a cutesy pout with ease.");
 				}
 				break;
 			case GLOBAL.TYPE_GABILANI:
 				outputRouter(" A pair of long, triangular goblin ears point outwards");
-				if(target.earLength > 1) outputRouter(" " + num2Text(target.earLength) + " inches");
+				if(target.earLength > 1) outputRouter(" " + UnitSystem.displayInchesTextually(target.earLength, 0));
 				outputRouter(" from " + (target == pc ? "your":"[target.hisHer]") + " " + headNoun + ".");
 				break;
 			case GLOBAL.TYPE_DEMONIC:
 				outputRouter(" A pair of wicked-looking ears point outwards");
-				if(target.earLength > 1) outputRouter(" " + num2Text(target.earLength) + " inches");
+				if(target.earLength > 1) outputRouter(" " + UnitSystem.displayInchesTextually(target.earLength, 0));
 				outputRouter(" from " + (target == pc ? "your":"[target.hisHer]") + " " + headNoun + ".");
 				break;
 			case GLOBAL.TYPE_FROG:
@@ -900,12 +898,12 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 				else if(target.earLength >= 3) outputRouter(" floppy");
 				else outputRouter(" rounded");
 				outputRouter(" dog ears protrude");
-				if(target.earLength >= 3) outputRouter(" " + num2Text(target.earLength) + " inches");
+				if(target.earLength >= 3) outputRouter(" " + UnitSystem.displayInchesTextually(target.earLength, 0));
 				outputRouter(" from " + (target == pc ? "your":"[target.hisHer]") + " " + headNoun + ", each capable of being highly expressive.");
 				break;
 			case GLOBAL.TYPE_SIREN:
 				outputRouter(" A pair of feather-tipped ears point outwards");
-				if(target.earLength > 1) outputRouter(" " + num2Text(target.earLength) + " inches");
+				if(target.earLength > 1) outputRouter(" " + UnitSystem.displayInchesTextually(target.earLength, 0));
 				outputRouter(" from " + (target == pc ? "your":"[target.hisHer]") + " " + headNoun + ".");
 				break;
 			case GLOBAL.TYPE_SHARK:
@@ -931,7 +929,7 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 				break;
 			case GLOBAL.TYPE_DZAAN:
 				outputRouter(" A pair of long, triangular dzaan ears point outwards");
-				if(target.earLength > 1) outputRouter(" " + num2Text(target.earLength) + " inches");
+				if(target.earLength > 1) outputRouter(" " + UnitSystem.displayInchesTextually(target.earLength, 0));
 				outputRouter(" from " + (target == pc ? "your":"[target.hisHer]") + " " + headNoun + ".");
 				break;
 			default:
@@ -963,7 +961,7 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 				outputRouter(" The " + target.hairDescript(true,true) + " on " + (target == pc ? "your":"[target.hisHer]") + " head is parted by a pair of sheep-like ears that flop cutely down the sides of " + (target == pc ? "your":"[target.hisHer]") + " head.");
 				break;
 			case GLOBAL.TYPE_GOAT:
-				outputRouter(" The " + target.hairDescript(true,true) + " on " + (target == pc ? "your":"[target.hisHer]") + " head is parted by a pair of " + num2Text(target.earLength) + "-inch long, flicking goat ears. They stick noticeably out to the sides");
+				outputRouter(" The " + target.hairDescript(true,true) + " on " + (target == pc ? "your":"[target.hisHer]") + " head is parted by a pair of " + UnitSystem.displayInchWithHyphenTextually(target.earLength, 0) + " long, flicking goat ears. They stick noticeably out to the sides");
 				if(!nonFurrySkin) outputRouter(" with tufts of fur on their backs");
 				outputRouter(".");
 				break;
@@ -1007,10 +1005,10 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 					if(target.earType == GLOBAL.TYPE_QUAD_LAPINE) outputRouter(" Two pairs of");
 					else outputRouter(" A pair of");
 					outputRouter(" alert rabbit ears stick up");
-					if(target.earLength >= target.tallness/2) outputRouter(" partway before their " + num2Text(target.earLength) + "-inch length drags them downward under their own weight.");
+					if(target.earLength >= target.tallness/2) outputRouter(" partway before their " + UnitSystem.displayInchWithHyphenTextually(target.earLength, 0) + " length drags them downward under their own weight.");
 					else
 					{
-						if(target.earLength > 1) outputRouter(" " + num2Text(target.earLength) + " inches");
+						if(target.earLength > 1) outputRouter(" " + UnitSystem.displayInchesTextually(target.earLength, 0));
 						outputRouter(" from the top of " + (target == pc ? "your":"[target.hisHer]") + " " + target.hairDescript(true,true) + ",");
 						if(target.earLength > target.tallness) outputRouter(" dragging on the floor");
 						else if(target.earLength > target.tallness/2) outputRouter(" swaying about");
@@ -1061,24 +1059,24 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 				break;
 			case GLOBAL.TYPE_RASKVEL:
 				outputRouter(" The " + target.hairDescript(true,true) + " atop " + (target == pc ? "your":"[target.hisHer]") + " head is parted by a pair of");
-				if(target.earLength >= (target.tallness * 0.6)) outputRouter(" " + num2Text(target.earLength) + "-inch");
+				if(target.earLength >= (target.tallness * 0.6)) outputRouter(" " + UnitSystem.displayInchWithHyphenTextually(target.earLength, 0));
 				outputRouter(" long raskvel ears that dangle down past " + (target == pc ? "your":"[target.hisHer]") + " waist.");
 				break;
 			case GLOBAL.TYPE_SYLVAN:
 				if(target.earLength <= 1) outputRouter(" The " + target.hairDescript(true,true) + " on " + (target == pc ? "your":"[target.hisHer]") + " head nearly conceals a pair of mostly-human ears with slightly pointed tips, just like a fantasy elf’s.");
 				//2-4 inches: 
-				else if(target.earLength <= 4) outputRouter(" The " + target.hairDescript(true,true) + " on " + (target == pc ? "your":"[target.hisHer]") + " head can’t hide a pair of triangular, elven ears. They stick out a full " + num2Text(target.earLength) + " inches from the sides of " + (target == pc ? "your":"[target.hisHer]") + " head. Small extra muscles let them twitch or droop expressively.");
+				else if(target.earLength <= 4) outputRouter(" The " + target.hairDescript(true,true) + " on " + (target == pc ? "your":"[target.hisHer]") + " head can’t hide a pair of triangular, elven ears. They stick out a full " + UnitSystem.displayInchesTextually(target.earLength, 0) + " from the sides of " + (target == pc ? "your":"[target.hisHer]") + " head. Small extra muscles let them twitch or droop expressively.");
 				//5+ inches:
-				else outputRouter(" The " + target.hairDescript(true,true) + " atop " + (target == pc ? "your":"[target.hisHer]") + " head can’t possibly hide a pair of exquisitely long, elf-like ears. They extend a full " + num2Text(target.earLength) + " inches from the sides of " + (target == pc ? "your":"[target.hisHer]") + " head, triangular in shape with a bit of downward curve along their length. A thought is all it takes for them to change their angle to suit " + (target == pc ? "your":"[target.hisHer]") + " expression, letting even the most rugged face pull off a cutesy pout with ease.");
+				else outputRouter(" The " + target.hairDescript(true,true) + " atop " + (target == pc ? "your":"[target.hisHer]") + " head can’t possibly hide a pair of exquisitely long, elf-like ears. They extend a full " + UnitSystem.displayInchesTextually(target.earLength, 0) + " from the sides of " + (target == pc ? "your":"[target.hisHer]") + " head, triangular in shape with a bit of downward curve along their length. A thought is all it takes for them to change their angle to suit " + (target == pc ? "your":"[target.hisHer]") + " expression, letting even the most rugged face pull off a cutesy pout with ease.");
 				break;
 			case GLOBAL.TYPE_GABILANI:
 				outputRouter(" The " + target.hairDescript(true,true) + " on " + (target == pc ? "your":"[target.hisHer]") + " head is parted by a pair of");
-				if(target.earLength > 1) outputRouter(" " + num2Text(target.earLength) + "-inch");
+				if(target.earLength > 1) outputRouter(" " + UnitSystem.displayInchWithHyphenTextually(target.earLength, 0));
 				outputRouter(" long, triangular goblin ears.");
 				break;
 			case GLOBAL.TYPE_DEMONIC:
 				outputRouter(" The " + target.hairDescript(true,true) + " on " + (target == pc ? "your":"[target.hisHer]") + " head is parted by a pair of");
-				if(target.earLength > 1) outputRouter(" " + num2Text(target.earLength) + "-inch long,");
+				if(target.earLength > 1) outputRouter(" " + UnitSystem.displayInchWithHyphenTextually(target.earLength, 0) + " long,");
 				outputRouter(" wicked-looking demonic ears.");
 				break;
 			case GLOBAL.TYPE_FROG:
@@ -1090,12 +1088,12 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 				if(target.earLength >= 6) outputRouter(" droopy");
 				else if(target.earLength >= 3) outputRouter(" floppy");
 				else outputRouter(" rounded");
-				if(target.earLength >= 3) outputRouter(", " + num2Text(target.earLength) + "-inch long");
+				if(target.earLength >= 3) outputRouter(", " + UnitSystem.displayInchWithHyphenTextually(target.earLength, 0) + " long");
 				outputRouter(" dog ears, each capable of being highly expressive.");
 				break;
 			case GLOBAL.TYPE_SIREN:
 				outputRouter(" The " + target.hairDescript(true,true) + " on " + (target == pc ? "your":"[target.hisHer]") + " head is parted by a pair of");
-				if(target.earLength > 1) outputRouter(" " + num2Text(target.earLength) + "-inch long,");
+				if(target.earLength > 1) outputRouter(" " + UnitSystem.displayInchWithHyphenTextually(target.earLength, 0) + " long,");
 				outputRouter(" feather-tipped ears.");
 				break;
 			case GLOBAL.TYPE_SHARK:
@@ -1118,7 +1116,7 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 				break;
 			case GLOBAL.TYPE_DZAAN:
 				outputRouter(" The " + target.hairDescript(true,true) + " on " + (target == pc ? "your":"[target.hisHer]") + " head is parted by a pair of");
-				if(target.earLength > 1) outputRouter(" " + num2Text(target.earLength) + "-inch");
+				if(target.earLength > 1) outputRouter(" " + UnitSystem.displayInchWithHyphenTextually(target.earLength, 0));
 				outputRouter(" long, triangular dzaan ears.");
 				break;
 			default:
@@ -1130,7 +1128,7 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 	if(target.earType == GLOBAL.TYPE_LEITHAN)
 	{
 		outputRouter(" In addition,");
-		if(target.earLength > 1) outputRouter(" " + num2Text(target.earLength) + "-inch long");
+		if(target.earLength > 1) outputRouter(" " + UnitSystem.displayInchWithHyphenTextually(target.earLength, 0) + " long");
 		outputRouter(" pointed elfin ears jut out below them, giving " + (target == pc ? "you":"[target.himHer]") + " exceptional hearing.");
 	}
 	if(target.hasStatusEffect("Laquine Ears"))
@@ -1181,10 +1179,10 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 			outputRouter(" A snake-like tongue occasionally flits between " + (target == pc ? "your":"[target.hisHer]") + " lips, tasting the air.");
 			break;
 		case GLOBAL.TYPE_DEMONIC:
-			outputRouter(" A slowly undulating tongue occasionally slips from between " + (target == pc ? "your":"[target.hisHer]") + " lips. It hangs nearly two feet long when " + (target == pc ? "you let":"[target.heShe] lets") + " the whole thing slide out, though " + (target == pc ? "you":"[target.heShe]") + " can retract it to appear normal.");
+			outputRouter(" A slowly undulating tongue occasionally slips from between " + (target == pc ? "your":"[target.hisHer]") + " lips. It hangs nearly " + UnitSystem.feetEstimateTextual(2) + " long when " + (target == pc ? "you let":"[target.heShe] lets") + " the whole thing slide out, though " + (target == pc ? "you":"[target.heShe]") + " can retract it to appear normal.");
 			break;
 		case GLOBAL.TYPE_DRACONIC:
-			outputRouter(" " + (target == pc ? "Your":"[target.HisHer]") + " mouth contains a thick, fleshy tongue that, if " + (target == pc ? "you so desire":"[target.heShe] so desires") + ", can telescope to a distance of about four feet. It has sufficient manual dexterity that " + (target == pc ? "you":"[target.heShe]") + " can use it almost like a third arm.");
+			outputRouter(" " + (target == pc ? "Your":"[target.HisHer]") + " mouth contains a thick, fleshy tongue that, if " + (target == pc ? "you so desire":"[target.heShe] so desires") + ", can telescope to a distance of about " + UnitSystem.feetEstimateTextual(4) + ". It has sufficient manual dexterity that " + (target == pc ? "you":"[target.heShe]") + " can use it almost like a third arm.");
 			break;
 		case GLOBAL.TYPE_LEITHAN:
 			outputRouter(" " + (target == pc ? "Your":"[target.HisHer]") + " mouth contains a narrow but flexible tongue that, if " + (target == pc ? "you so desire":"[target.heShe] so desires") + ", can extend a good distance out from " + (target == pc ? "your":"[target.hisHer]") + " mouth. Its tip is forked, and " + (target == pc ? "you are":"[target.heShe] is") + " capable of moving it around in an almost prehensile manner.");
@@ -1193,14 +1191,14 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 			outputRouter(" " + (target == pc ? "Your":"[target.HisHer]") + " mouth contains a thick, purple tongue that, if " + (target == pc ? "you so desire":"[target.heShe] so desires") + ", can extend a fair portion from " + (target == pc ? "your":"[target.hisHer]") + " mouth. Its tip is blunted slightly.");
 			break;
 		case GLOBAL.TYPE_OVIR:
-			if(target.hasTongueFlag(GLOBAL.FLAG_LONG)) outputRouter(" A lengthy, tapered tongue fills " + (target == pc ? "your":"[target.hisHer]") + " mouth, able to stretch out almost nine inches in order to taste the very air.");
+			if(target.hasTongueFlag(GLOBAL.FLAG_LONG)) outputRouter(" A lengthy, tapered tongue fills " + (target == pc ? "your":"[target.hisHer]") + " mouth, able to stretch out almost " + UnitSystem.inchesEstimateTextual(9) + " in order to taste the very air.");
 			else outputRouter(" A tapered tongue fills " + (target == pc ? "your":"[target.hisHer]") + " mouth, able to taste the very air when extended beyond " + (target == pc ? "your":"[target.hisHer]") + " oral cavity.");
 			break;
 		case GLOBAL.TYPE_BEE:
-			outputRouter(" " + (target == pc ? "Your":"[target.HisHer]") + " mouth contains a long, bright yellow tongue that can extend a foot past past " + (target == pc ? "your":"[target.hisHer]") + " [target.lipsChaste] when fully extended. The tip has a tube inside it, capable of gathering sweet nectar from jungle flowers or lovers.");
+			outputRouter(" " + (target == pc ? "Your":"[target.HisHer]") + " mouth contains a long, bright yellow tongue that can extend " + UnitSystem.aFoot() + " past " + (target == pc ? "your":"[target.hisHer]") + " [target.lipsChaste] when fully extended. The tip has a tube inside it, capable of gathering sweet nectar from jungle flowers or lovers.");
 			break;
 		case GLOBAL.TYPE_MOTHRINE:
-			outputRouter(" " + (target == pc ? "Your":"[target.HisHer]") + " mouth contains a long tongue that can extend a foot past past " + (target == pc ? "your":"[target.hisHer]") + " [target.lipsChaste] when fully extended. The tip has a tube inside it, capable of gathering sweet nectar from jungle flowers or lovers.");
+			outputRouter(" " + (target == pc ? "Your":"[target.HisHer]") + " mouth contains a long tongue that can extend " + UnitSystem.aFoot() + " past " + (target == pc ? "your":"[target.hisHer]") + " [target.lipsChaste] when fully extended. The tip has a tube inside it, capable of gathering sweet nectar from jungle flowers or lovers.");
 			break;
 		case GLOBAL.TYPE_FROG:
 			if(target.hasTongueFlag(GLOBAL.FLAG_LONG)) outputRouter(" " + (target == pc ? "Your":"[target.HisHer]") + " mouth contains a long and stretchy frog tongue, capable of reaching much longer distances than most races.");
@@ -1213,7 +1211,7 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 			outputRouter(" " + (target == pc ? "Your":"[target.HisHer]") + " mouth contains a long blue tongue that dangles over " + (target == pc ? "your":"[target.hisHer]") + " lower lip whenever " + (target == pc ? "you stop":"[target.heShe] stops") + " thinking about it.");
 			break;
 		case GLOBAL.TYPE_BOVINE:
-			if(target.hasTongueFlag(GLOBAL.FLAG_LONG)) outputRouter(" " + (target == pc ? "Your":"[target.HisHer]") + " mouth houses a broad, prehensile tongue which extends over a foot long with a smooth surface that is perfect for pleasuring sensitive areas.");
+			if(target.hasTongueFlag(GLOBAL.FLAG_LONG)) outputRouter(" " + (target == pc ? "Your":"[target.HisHer]") + " mouth houses a broad, prehensile tongue which extends over " + UnitSystem.aFoot() + " long with a smooth surface that is perfect for pleasuring sensitive areas.");
 			else outputRouter(" " + (target == pc ? "Your":"[target.HisHer]") + " mouth contains a smooth, broad tongue, perfect for pleasuring sensitive spots.");
 			break;
 		case GLOBAL.TYPE_TENTACLE:
@@ -1224,7 +1222,7 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 			if (target.hasTongueFlag(GLOBAL.FLAG_LONG)) outputRouter(" long");
 			outputRouter(" pink tube of");
 			if (target.hasTongueFlag(GLOBAL.FLAG_PREHENSILE)) outputRouter(" practically prehensile");
-			outputRouter(" flesh, capable of extending up to four feet in length when " + (target == pc ? "you let":"[target.heShe] lets") + " it hang down all the way.");
+			outputRouter(" flesh, capable of extending up to " + UnitSystem.feetEstimateTextual(4) + " in length when " + (target == pc ? "you let":"[target.heShe] lets") + " it hang down all the way.");
 			break;
 		//Tired of seeing "your mouth contains a tongue."
 		case GLOBAL.TYPE_HUMAN:
@@ -1255,44 +1253,44 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 		{
 			//Demonic horns
 			case GLOBAL.TYPE_DEMONIC:
-				if(target.horns <= 2) outputRouter(" A " + (target.hornLength <= 2 ? "small pair of" : ("pair of " + num2Text(int(target.hornLength)) + "-inch long")) + " pointed horns has broken through the " + target.skin() + " on " + (target == pc ? "your":"[target.hisHer]") + " forehead, proclaiming some demonic taint to any who see them.");
-				else if(target.horns <= 4) outputRouter(" A quartet of " + (target.hornLength <= 4 ? "prominent" : (num2Text(int(target.hornLength)) + "-inch long")) + " horns has broken through " + (target == pc ? "your":"[target.hisHer]") + " " + target.skin() + ". The back pair are longer, and curve back along " + (target == pc ? "your":"[target.hisHer]") + " head. The front pair protrude forward demonically.");
-				else if(target.horns <= 6) outputRouter(" Six horns have sprouted through " + (target == pc ? "your":"[target.hisHer]") + " " + target.skin() + ", the back two pairs curve backwards over " + (target == pc ? "your":"[target.hisHer]") + " head and down towards " + (target == pc ? "your":"[target.hisHer]") + " neck, while the front two horns stand " + (target.hornLength < 8 ? "almost eight" : num2Text(int(target.hornLength))) + " inches long upwards and a little forward.");
-				else outputRouter(" A large number of thick demonic horns sprout through " + (target == pc ? "your":"[target.hisHer]") + " " + target.skin() + ", each pair sprouting behind the ones before. The front jut forwards nearly " + num2Text(int(target.hornLength)) + " inches while the rest curve back over " + (target == pc ? "your":"[target.hisHer]") + " head, some of the points ending just below " + (target == pc ? "your":"[target.hisHer]") + " ears. " + (target == pc ? "You estimate you have":"[target.HeShe] estimates [target.heShe] has") + " a total of " + num2Text(target.horns) + " horns.");
+				if(target.horns <= 2) outputRouter(" A " + (target.hornLength <= 2 ? "small pair of" : ("pair of " + UnitSystem.displayInchWithHyphenTextually(target.hornLength, 0) + " long")) + " pointed horns has broken through the " + target.skin() + " on " + (target == pc ? "your":"[target.hisHer]") + " forehead, proclaiming some demonic taint to any who see them.");
+				else if(target.horns <= 4) outputRouter(" A quartet of " + (target.hornLength <= 4 ? "prominent" : (UnitSystem.displayInchWithHyphenTextually(target.hornLength, 0) + " long")) + " horns has broken through " + (target == pc ? "your":"[target.hisHer]") + " " + target.skin() + ". The back pair are longer, and curve back along " + (target == pc ? "your":"[target.hisHer]") + " head. The front pair protrude forward demonically.");
+				else if(target.horns <= 6) outputRouter(" Six horns have sprouted through " + (target == pc ? "your":"[target.hisHer]") + " " + target.skin() + ", the back two pairs curve backwards over " + (target == pc ? "your":"[target.hisHer]") + " head and down towards " + (target == pc ? "your":"[target.hisHer]") + " neck, while the front two horns stand " + (target.hornLength < 8 ? "almost " + UnitSystem.inchesEstimateTextual(8) : UnitSystem.displayInchesTextually(target.hornLength, 0)) + " long upwards and a little forward.");
+				else outputRouter(" A large number of thick demonic horns sprout through " + (target == pc ? "your":"[target.hisHer]") + " " + target.skin() + ", each pair sprouting behind the ones before. The front jut forwards nearly " + UnitSystem.displayInchesTextually(target.hornLength, 0) + " while the rest curve back over " + (target == pc ? "your":"[target.hisHer]") + " head, some of the points ending just below " + (target == pc ? "your":"[target.hisHer]") + " ears. " + (target == pc ? "You estimate you have":"[target.HeShe] estimates [target.heShe] has") + " a total of " + num2Text(target.horns) + " horns.");
 				break;
 			//Minotaur horns
 			case GLOBAL.TYPE_BOVINE:
 				if(target.hornLength < 1) outputRouter(" Two tiny horn-like nubs protrude from " + (target == pc ? "your":"[target.hisHer]") + " forehead, resembling the horns of the young livestock kept by terrans.");
-				else if(target.hornLength < 2) outputRouter(" Two small, roughly one-inch long bovine horns protrude from " + (target == pc ? "your":"[target.hisHer]") + " forehead. They’re kind of cute, actually.");
-				else if(target.hornLength < 3) outputRouter(" Two bovine horns, approximately two inches in length, jut from " + (target == pc ? "your":"[target.hisHer]") + " forehead.");
-				else if(target.hornLength < 4) outputRouter(" A pair of bovine horns jut a full three inches from " + (target == pc ? "your":"[target.hisHer]") + " forehead.");
-				else if(target.hornLength < 5) outputRouter(" Two horns protrude through the [target.skin] of " + (target == pc ? "your":"[target.hisHer]") + " forehead. Each is about four inches in length and impossible to ignore.");
+				else if(target.hornLength < 2) outputRouter(" Two small, roughly " + UnitSystem.displayInchWithHyphenTextually(1, 0) + " long bovine horns protrude from " + (target == pc ? "your":"[target.hisHer]") + " forehead. They’re kind of cute, actually.");
+				else if(target.hornLength < 3) outputRouter(" Two bovine horns, approximately " + UnitSystem.inchesEstimateTextual(2) + " in length, jut from " + (target == pc ? "your":"[target.hisHer]") + " forehead.");
+				else if(target.hornLength < 4) outputRouter(" A pair of bovine horns jut a full " + UnitSystem.inchesEstimateTextual(3) + " from " + (target == pc ? "your":"[target.hisHer]") + " forehead.");
+				else if(target.hornLength < 5) outputRouter(" Two horns protrude through the [target.skin] of " + (target == pc ? "your":"[target.hisHer]") + " forehead. Each is about " + UnitSystem.inchesEstimateTextual(4) + " in length and impossible to ignore.");
 				else if(target.hornLength < 6) outputRouter(" Two big, strong bovine horns jut from " + (target == pc ? "your":"[target.hisHer]") + " forehead. Their weight is a constant reminder just how much you look like a " + target.mf("bull","cow") + ".");
-				else if(target.hornLength < 8) outputRouter(" A pair of roughly half a foot of powerful, bovine horns protrude from " + (target == pc ? "your":"[target.hisHer]") + " skull. All " + (target == pc ? "you have":"[target.heShe] has") + " to do is lower " + (target == pc ? "your":"[target.hisHer]") + " head, and suddenly, " + (target == pc ? "you look":"[target.heShe] looks") + " quite dangerous.");
+				else if(target.hornLength < 8) outputRouter(" A pair of roughly " + UnitSystem.halfAFoot() + " of powerful, bovine horns protrude from " + (target == pc ? "your":"[target.hisHer]") + " skull. All " + (target == pc ? "you have":"[target.heShe] has") + " to do is lower " + (target == pc ? "your":"[target.hisHer]") + " head, and suddenly, " + (target == pc ? "you look":"[target.heShe] looks") + " quite dangerous.");
 				else if(target.hornLength < 12) outputRouter(" Two large horns sprout from " + (target == pc ? "your":"[target.hisHer]") + " forehead, curving forwards like those of a bull.");
-				else if(target.hornLength < 20) outputRouter(" Two very large and dangerous looking horns sprout from " + (target == pc ? "your":"[target.hisHer]") + " head, curving forward and over a foot long. They have dangerous looking points.");
+				else if(target.hornLength < 20) outputRouter(" Two very large and dangerous looking horns sprout from " + (target == pc ? "your":"[target.hisHer]") + " head, curving forward and over " + UnitSystem.aFoot() + " long. They have dangerous looking points.");
 				else outputRouter(" Two huge horns erupt from " + (target == pc ? "your":"[target.hisHer]") + " forehead, curving outward at first, then forwards. The weight of them is heavy, and they end in dangerous looking points.");
 				break;
 			//Lizard horns
 			case GLOBAL.TYPE_LIZAN:
 			case GLOBAL.TYPE_DRACONIC:
-				if(target.horns == 2 && target.hornType != GLOBAL.TYPE_DRACONIC) outputRouter(" A pair of " + num2Text(int(target.hornLength)) + "-inch horns grow from the sides of " + (target == pc ? "your":"[target.hisHer]") + " head, sweeping backwards and adding to " + (target == pc ? "your":"[target.hisHer]") + " imposing visage.");
+				if(target.horns == 2 && target.hornType != GLOBAL.TYPE_DRACONIC) outputRouter(" A pair of " + UnitSystem.displayInchWithHyphenTextually(target.hornLength, 0) + " horns grow from the sides of " + (target == pc ? "your":"[target.hisHer]") + " head, sweeping backwards and adding to " + (target == pc ? "your":"[target.hisHer]") + " imposing visage.");
 				//Super lizard horns
-				else outputRouter(" Two pairs of horns, roughly a foot long, sprout from the sides of " + (target == pc ? "your":"[target.hisHer]") + " head. They sweep back and give " + (target == pc ? "you":"[target.himHer]") + " a fearsome look, almost like the dragons from terran legends.");
+				else outputRouter(" Two pairs of horns, roughly " + UnitSystem.aFoot() + " long, sprout from the sides of " + (target == pc ? "your":"[target.hisHer]") + " head. They sweep back and give " + (target == pc ? "you":"[target.himHer]") + " a fearsome look, almost like the dragons from terran legends.");
 				break;
 			case GLOBAL.TYPE_GRYVAIN:
-				outputRouter(" A pair of " + num2Text(int(target.hornLength)) + "-inch horns grow from just above " + (target == pc ? "your":"[target.hisHer]") + " forehead, sweeping backwards to follow the contour of " + (target == pc ? "your":"[target.hisHer]") + " skull.");
+				outputRouter(" A pair of " + UnitSystem.displayInchWithHyphenTextually(target.hornLength, 0) + " horns grow from just above " + (target == pc ? "your":"[target.hisHer]") + " forehead, sweeping backwards to follow the contour of " + (target == pc ? "your":"[target.hisHer]") + " skull.");
 				if(target.isBimbo()) outputRouter(" They’d make the most <i>adorable</i> handlebars for anybody looking to bust a nut down " + (target == pc ? "your":"[target.hisHer]") + " throat!");
 				break;
 			//Antlers!
 			case GLOBAL.TYPE_DEER:
 				if(rand(2) == 0) outputRouter(" A pair of antlers sprout from " + (target == pc ? "your":"[target.hisHer]") + " head, covered in velvet and indicating " + (target == pc ? "your":"[target.hisHer]") + " status as a desirable mate.");
 				else outputRouter(" Velvet-covered antlers sprout from " + (target == pc ? "your":"[target.hisHer]") + " head, declaring " + (target == pc ? "your":"[target.hisHer]") + " status as a desirable mate and formidable opponent.");
-				if(target.hornLength > 1) outputRouter(" They are " + num2Text(int(target.hornLength)) + "-inch long and fork into " + num2Text(target.horns) + " points.");
+				if(target.hornLength > 1) outputRouter(" They are " + UnitSystem.displayInchWithHyphenTextually(target.hornLength, 0) + " long and fork into " + num2Text(target.horns) + " points.");
 				break;
 			case GLOBAL.TYPE_DRYAD:
 				outputRouter(" Two");
-				if(target.hornLength > 1) outputRouter(" " + num2Text(int(target.hornLength)) + "-inch long");
+				if(target.hornLength > 1) outputRouter(" " + UnitSystem.displayInchWithHyphenTextually(target.hornLength, 0) + " long");
 				outputRouter(" antlers, forking into " + num2Text(target.horns) + " points, have sprouted from the top of " + (target == pc ? "your":"[target.hisHer]") + " head, forming a spiky, regal crown of branches.");
 				break;
 			//Goatliness is next to godliness.
@@ -1307,19 +1305,19 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 						switch(hornStyle)
 						{
 							case 1:
-								outputRouter(" The curled goat horns coil out from the sides of " + (target == pc ? "your":"[target.hisHer]") + " forehead, " + num2Text(int(target.hornLength)) + " inches to the left and right.");
+								outputRouter(" The curled goat horns coil out from the sides of " + (target == pc ? "your":"[target.hisHer]") + " forehead, " + UnitSystem.displayInchesTextually(target.hornLength, 0) + " to the left and right.");
 								break;
 							case 2:
-								outputRouter(" The bow-curved goat horns extend in opposite directions from the sides of " + (target == pc ? "your":"[target.hisHer]") + " forehead, " + num2Text(int(target.hornLength)) + " inches to the left and right.");
+								outputRouter(" The bow-curved goat horns extend in opposite directions from the sides of " + (target == pc ? "your":"[target.hisHer]") + " forehead, " + UnitSystem.displayInchesTextually(target.hornLength, 0) + " to the left and right.");
 								break;
 							case 3:
-								outputRouter(" The thick ibex-like horns rise " + num2Text(int(target.hornLength)) + " inches into the air, curving towards " + (target == pc ? "your":"[target.hisHer]") + " back in a regal manner.");
+								outputRouter(" The thick ibex-like horns rise " + UnitSystem.displayInchesTextually(target.hornLength, 0) + " into the air, curving towards " + (target == pc ? "your":"[target.hisHer]") + " back in a regal manner.");
 								break;
 							case 4:
-								outputRouter(" The oryx-like horns rise " + num2Text(int(target.hornLength)) + " inches into the air, thin and mostly straight aside a slight bend towards the floor.");
+								outputRouter(" The oryx-like horns rise " + UnitSystem.displayInchesTextually(target.hornLength, 0) + " into the air, thin and mostly straight aside a slight bend towards the floor.");
 								break;
 							case 5:
-								outputRouter(" The markhor-like horns rise " + num2Text(int(target.hornLength)) + " inches into the air, twisted and alien in shape.");
+								outputRouter(" The markhor-like horns rise " + UnitSystem.displayInchesTextually(target.hornLength, 0) + " into the air, twisted and alien in shape.");
 								break;
 						}
 					}
@@ -1343,22 +1341,22 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 			//Rhinoceros horn!
 			case GLOBAL.TYPE_RHINO:
 				// Default
-				if(target.horns == 1) outputRouter(" A thick, wide keratin horn emerges from " + (target == pc ? "your":"[target.hisHer]") + " forehead, " + num2Text(int(target.hornLength)) + "-inches long and sporting a slight upward curve.");
+				if(target.horns == 1) outputRouter(" A thick, wide keratin horn emerges from " + (target == pc ? "your":"[target.hisHer]") + " forehead, " + UnitSystem.displayInchesWithHyphenTextually(target.hornLength, 0) + " long and sporting a slight upward curve.");
 				// More rhino-esque
-				else if(target.horns == 2) outputRouter(" Protruding from the bridge of " + (target == pc ? "your":"[target.hisHer]") + " nose, a thick, " + num2Text(int(target.hornLength)) + "-inch long keratin horn emerges, sporting a slight upward curve and followed by a smaller, smoother bump of horn right behind it.");
+				else if(target.horns == 2) outputRouter(" Protruding from the bridge of " + (target == pc ? "your":"[target.hisHer]") + " nose, a thick, " + UnitSystem.displayInchWithHyphenTextually(target.hornLength, 0) + " long keratin horn emerges, sporting a slight upward curve and followed by a smaller, smoother bump of horn right behind it.");
 				// Triceratops!
-				else if(target.horns == 3) outputRouter(" Two thick, wide keratin horns emerge from " + (target == pc ? "your":"[target.hisHer]") + " forehead, " + num2Text(int(target.hornLength)) + "-inches long with a slight upward curve. A third, smaller horn protrudes from, and perpendicular to, " + (target == pc ? "your":"[target.hisHer]") + " nose bridge.");
+				else if(target.horns == 3) outputRouter(" Two thick, wide keratin horns emerge from " + (target == pc ? "your":"[target.hisHer]") + " forehead, " + UnitSystem.displayInchesWithHyphenTextually(target.hornLength, 0) + " long with a slight upward curve. A third, smaller horn protrudes from, and perpendicular to, " + (target == pc ? "your":"[target.hisHer]") + " nose bridge.");
 				// Too many horns...
-				else outputRouter(" Thick, keratin horns emerge from " + (target == pc ? "your":"[target.hisHer]") + " forehead and face, all varying sizes, with the largest at about " + num2Text(int(target.hornLength)) + "-inches long. They all protrude forward and slightly curve upwards, creating a very menacing pincusion-like visage.");
+				else outputRouter(" Thick, keratin horns emerge from " + (target == pc ? "your":"[target.hisHer]") + " forehead and face, all varying sizes, with the largest at about " + UnitSystem.displayInchesWithHyphenTextually(target.hornLength, 0) + " long. They all protrude forward and slightly curve upwards, creating a very menacing pincusion-like visage.");
 				break;
 			//Unicorn horn!
 			case GLOBAL.TYPE_NARWHAL:
-				outputRouter(" A slender ivory horn extends from " + (target == pc ? "your":"[target.hisHer]") + " forehead, " + num2Text(int(target.hornLength)) + "-inches long with a spiral pattern of ridges and grooves up its length, giving it a graceful appearance.");
+				outputRouter(" A slender ivory horn extends from " + (target == pc ? "your":"[target.hisHer]") + " forehead, " + UnitSystem.displayInchesWithHyphenTextually(target.hornLength, 0) + " long with a spiral pattern of ridges and grooves up its length, giving it a graceful appearance.");
 				break;
 			case GLOBAL.TYPE_FROSTWYRM:
 				outputRouter(" A pair of ivory, thick horns extend from " + (target == pc ? "your":"[target.hisHer]") + " forehead, arcing upward and over " + (target == pc ? "your":"[target.hisHer]") + " skull, sort of like they’re protecting " + (target == pc ? "you":"[target.himHer]") + " from anything that might fall onto " + (target == pc ? "your":"[target.hisHer]") + " head. They’re each");
-				if (target.hornLength < 8 || target.hornLength > 12) outputRouter(num2Text(int(target.hornLength)) + "-inches long");
-				else outputRouter(" maybe a foot long");
+				if (target.hornLength < 8 || target.hornLength > 12) outputRouter(UnitSystem.displayInchesWithHyphenTextually(target.hornLength, 0) + " long");
+				else outputRouter(" maybe " + UnitSystem.aFoot() + " long");
 				outputRouter(" and as thick as two or three fingers together. They’re useless for attacking, but they provide decent coverage - and they no doubt add to your imposing visage");
 				if (target.race() == "frostwyrm") outputRouter(" as a Frostwyrm.");
 				else outputRouter(".");
@@ -1368,7 +1366,7 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 				if (hornMaterial <= 0 || hornColor == "") outputRouter(" " + (target == pc ? "Your":"[target.HisHer]") + " curved horns are [target.skinColor] at their base, but fade into gold at their tips.");
 				break;
 			case GLOBAL.TYPE_SAURMORIAN:
-				outputRouter(" A pair of dense, metal horns, roughly " + num2Text(int(target.hornLength)) + " inches long, curve up and along the back of " + (target == pc ? "your":"[target.hisHer]") + " skull");
+				outputRouter(" A pair of dense, metal horns, roughly " + UnitSystem.displayInchesTextually(target.hornLength, 0) + " long, curve up and along the back of " + (target == pc ? "your":"[target.hisHer]") + " skull");
 				if (target.hornLength >= 18) outputRouter(" and over " + (target == pc ? "your":"[target.hisHer]") + " head before twisting upwards at the brow");
 				if (target.horns == 3) outputRouter(". At the tip of " + (target == pc ? "your":"[target.hisHer]") + " [target.face], just above " + (target == pc ? "your":"[target.hisHer]") + " nose, sits a third, shorter horn");
 				outputRouter(". They have a rather intimidating presence, as if reminiscent of a more savage time.");
@@ -1376,14 +1374,14 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 			//Dzaan horns!
 			case GLOBAL.TYPE_DZAAN:
 				if(target.hornLength < 1) outputRouter(" " + StringUtil.capitalize(num2Text(target.horns)) + " tiny keratin nubs protrude from " + (target == pc ? "your":"[target.hisHer]") + " forehead.");
-				else if(target.hornLength < 2) outputRouter(" " + StringUtil.capitalize(num2Text(target.horns)) + " small, roughly one-inch long keratin horns protrude from " + (target == pc ? "your":"[target.hisHer]") + " forehead. They’re kind of cute, actually.");
-				else if(target.hornLength < 3) outputRouter(" " + StringUtil.capitalize(num2Text(target.horns)) + " keratin horns, approximately two inches in length, jut from " + (target == pc ? "your":"[target.hisHer]") + " forehead.");
-				else if(target.hornLength < 4) outputRouter(" " + StringUtil.capitalize(num2Text(target.horns)) + " keratin horns jut a full three inches from " + (target == pc ? "your":"[target.hisHer]") + " forehead and curve upwards.");
-				else if(target.hornLength < 5) outputRouter(" " + StringUtil.capitalize(num2Text(target.horns)) + " keratin horns protrude through the [target.skin] of " + (target == pc ? "your":"[target.hisHer]") + " forehead and curve backwards. Each is about four inches in length and impossible to ignore.");
+				else if(target.hornLength < 2) outputRouter(" " + StringUtil.capitalize(num2Text(target.horns)) + " small, roughly " + UnitSystem.displayInchWithHyphenTextually(1, 0) + " long keratin horns protrude from " + (target == pc ? "your":"[target.hisHer]") + " forehead. They’re kind of cute, actually.");
+				else if(target.hornLength < 3) outputRouter(" " + StringUtil.capitalize(num2Text(target.horns)) + " keratin horns, approximately " + UnitSystem.inchesEstimateTextual(2) + " in length, jut from " + (target == pc ? "your":"[target.hisHer]") + " forehead.");
+				else if(target.hornLength < 4) outputRouter(" " + StringUtil.capitalize(num2Text(target.horns)) + " keratin horns jut a full " + UnitSystem.inchesEstimateTextual(3) + " from " + (target == pc ? "your":"[target.hisHer]") + " forehead and curve upwards.");
+				else if(target.hornLength < 5) outputRouter(" " + StringUtil.capitalize(num2Text(target.horns)) + " keratin horns protrude through the [target.skin] of " + (target == pc ? "your":"[target.hisHer]") + " forehead and curve backwards. Each is about " + UnitSystem.inchesEstimateTextual(4) + " in length and impossible to ignore.");
 				else if(target.hornLength < 6) outputRouter(" " + StringUtil.capitalize(num2Text(target.horns)) + " big, strong keratin horns jut from " + (target == pc ? "your":"[target.hisHer]") + " forehead and curve backwards.");
-				else if(target.hornLength < 8) outputRouter(" " + StringUtil.capitalize(num2Text(target.horns)) + " keratin horns protrude from " + (target == pc ? "your":"[target.hisHer]") + " skull, each powerful and half a foot long with a natural backwards-facing curve.");
+				else if(target.hornLength < 8) outputRouter(" " + StringUtil.capitalize(num2Text(target.horns)) + " keratin horns protrude from " + (target == pc ? "your":"[target.hisHer]") + " skull, each powerful and " + UnitSystem.halfAFoot() + " long with a natural backwards-facing curve.");
 				else if(target.hornLength < 12) outputRouter(" " + StringUtil.capitalize(num2Text(target.horns)) + " large keratin horns sprout from " + (target == pc ? "your":"[target.hisHer]") + " forehead, curving back over " + (target == pc ? "your":"[target.hisHer]") + " head and looking quite alluring.");
-				else if(target.hornLength < 20) outputRouter(" " + StringUtil.capitalize(num2Text(target.horns)) + " very large and dangerous looking keratin horns sprout from " + (target == pc ? "your":"[target.hisHer]") + " head, curving backward and over a foot long. They appear both imposing and alluring.");
+				else if(target.hornLength < 20) outputRouter(" " + StringUtil.capitalize(num2Text(target.horns)) + " very large and dangerous looking keratin horns sprout from " + (target == pc ? "your":"[target.hisHer]") + " head, curving backward and over " + UnitSystem.aFoot() + " long. They appear both imposing and alluring.");
 				else outputRouter(" " + StringUtil.capitalize(num2Text(target.horns)) + " huge keratin horns erupt from " + (target == pc ? "your":"[target.hisHer]") + " forehead, curving upward and backwards. The weight of them is noticeable but their size commands attention.");
 				break;
 		}
@@ -1586,7 +1584,7 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 				outputRouter(" " + (target.wingCount == 2 ? "a pair of":num2Text(int(target.wingCount))) + " majestic reptilian wings sprout from " + (target == pc ? "your":"[target.hisHer]") + " back. Your arms are covered in [target.scaleColor] scales, each bone tipped with a small talon, while the membranes are a glittering silver shade that produces a mesmerizing display in the light. Thanks to " + (target == pc ? "your":"[target.hisHer]") + " smaller size, they have no trouble bearing " + (target == pc ? "you":"[target.himHer]") + " aloft even without the frostwyrm’s psionic abilities.");
 				break;
 			case GLOBAL.TYPE_JANERIA:
-				outputRouter(" " + (target.wingCount == 4 ? "a quartet of":num2Text(int(target.wingCount))) + " large [target.skinColor] tentacles sprout from just behind " + (target == pc ? "your":"[target.hisHer]") + " shoulders, curling upward before drooping down so that the tips hang just a few inches above the ground. Each ends in a huge diamond-shaped pad, featureless but lightly sticky to the touch on one side while smooth and slippery on the other. When you curl the sticky sides of the pads inward, the result looks distinctly phallic.");
+				outputRouter(" " + (target.wingCount == 4 ? "a quartet of":num2Text(int(target.wingCount))) + " large [target.skinColor] tentacles sprout from just behind " + (target == pc ? "your":"[target.hisHer]") + " shoulders, curling upward before drooping down so that the tips hang just a few " + UnitSystem.literalInches() + " above the ground. Each ends in a huge diamond-shaped pad, featureless but lightly sticky to the touch on one side while smooth and slippery on the other. When you curl the sticky sides of the pads inward, the result looks distinctly phallic.");
 				break;
 		}
 	}
@@ -2519,7 +2517,7 @@ public function appearance(forTarget:Creature, backTarget:Function = null):void
 			// Bulbous
 			else if(target.tailGenitalArg == GLOBAL.TYPE_CANINE)
 			{
-				outputRouter(" Most of the length of the thing is coated in " + cockvineTexture + ", culminating in a thick bulge a few inches below a tapered,");
+				outputRouter(" Most of the length of the thing is coated in " + cockvineTexture + ", culminating in a thick bulge a few " + UnitSystem.literalInches() + " below a tapered,");
 				if(target.tailGenitalColor != "") outputRouter(" " + target.tailGenitalColor);
 				else outputRouter(" dark-red");
 				outputRouter(" tip.");
@@ -3444,15 +3442,15 @@ public function boobStuff(forTarget:Creature = null):void
 		if(InCollection(target.breastRows[0].nippleType, [GLOBAL.NIPPLE_TYPE_DICK, GLOBAL.NIPPLE_TYPE_NORMAL]))
 		{ 
 			//One nipple
-			if(target.nipplesPerBreast == 1) outputRouter(num2Text(target.nipplesPerBreast) + " " + num2Text(int(target.nippleLength(0)*10)/10) + "-inch " + target.nippleDescript(0) + " each.");
-			else outputRouter(num2Text(target.nipplesPerBreast) + " " + num2Text(int(target.nippleLength(0)*10)/10) + "-inch " + plural(target.nippleDescript(0)) + " each.");
+			if(target.nipplesPerBreast == 1) outputRouter(num2Text(target.nipplesPerBreast) + " " + UnitSystem.displayInchWithHyphenTextually(target.nippleLength(0)) + " " + target.nippleDescript(0) + " each.");
+			else outputRouter(num2Text(target.nipplesPerBreast) + " " + UnitSystem.displayInchWithHyphenTextually(target.nippleLength(0)) + " " + plural(target.nippleDescript(0)) + " each.");
 			//Dicknipples mention areolae desc later.
 			if(target.breastRows[0].nippleType == GLOBAL.NIPPLE_TYPE_DICK) outputRouter(" The " + target.areolaeDescript(0, true) + " are " + target.nippleColor + ".");
 			else outputRouter(" The " + target.areolaeDescript(0, true) + " are " + target.nippleColor + ".");
 			if(target.breastRows[0].nippleType == GLOBAL.NIPPLE_TYPE_DICK)
 			{
 				//New J-Cup hotness
-				outputRouter(" With a lusty thought and a bit of focus, " + (target == pc ? "you":"[target.heShe]") + " can make " + num2Text(Math.round(target.nippleLength(0) * target.dickNippleMultiplier * 10)/10) + "-inch " + target.nippleCocksDescript(true) + " slide out from behind " + (target == pc ? "your":"[target.hisHer]") + " " + target.areolaeDescript(0, true) + ".");
+				outputRouter(" With a lusty thought and a bit of focus, " + (target == pc ? "you":"[target.heShe]") + " can make " + UnitSystem.displayInchWithHyphenTextually(target.nippleLength(0) * target.dickNippleMultiplier) + " " + target.nippleCocksDescript(true) + " slide out from behind " + (target == pc ? "your":"[target.hisHer]") + " " + target.areolaeDescript(0, true) + ".");
 				//OLD: outputRouter(" With a lusty thought and a bit of focus, you can make " + num2Text(Math.round(target.nippleLength(0) * target.dickNippleMultiplier * 10)/10) + "-inch " + target.nippleCocksDescript(true) + " slide out from behind your " + target.areolaeDescript(0, true) + ".");
 			}
 		}
@@ -3475,7 +3473,7 @@ public function boobStuff(forTarget:Creature = null):void
 					break;
 				case GLOBAL.NIPPLE_TYPE_INVERTED:
 					outputRouter(" The " + target.areolaeDescript(0, true) + " are " + target.nippleColor + ".");
-					outputRouter(" When " + (target == pc ? "you’re":"[target.heShe]’s") + " aroused enough, " + (target == pc ? "your":"[target.hisHer]") + " " + num2Text(int(target.nippleLength(0)*10)/10) + "-inch nipples pop out, ready for action.");
+					outputRouter(" When " + (target == pc ? "you’re":"[target.heShe]’s") + " aroused enough, " + (target == pc ? "your":"[target.hisHer]") + " " + UnitSystem.displayInchWithHyphenTextually(target.nippleLength(0)) + " nipples pop out, ready for action.");
 					break;
 				case GLOBAL.NIPPLE_TYPE_TENTACLED:
 					outputRouter(" Once " + (target == pc ? "you are":"[target.heShe] is") + " worked up, several long, prehensile tentacles emerge from their " + target.nippleColor + " home, seeking for an orifice to pleasure.");
@@ -3585,17 +3583,17 @@ public function boobStuff(forTarget:Creature = null):void
 				}
 				//One nipple
 				if(target.nipplesPerBreast == 1) {
-					outputRouter(num2Text(target.nipplesPerBreast) + " " + num2Text(int(target.nippleLength(temp)*10)/10) + "-inch " + target.nippleDescript(temp) + " ");
+					outputRouter(num2Text(target.nipplesPerBreast) + " " + UnitSystem.displayInchWithHyphenTextually(target.nippleLength(temp)) + " " + target.nippleDescript(temp) + " ");
 					if(target.breastRows[temp].breastRating() < 1) outputRouter("on each side.");
 					else outputRouter("each.");
 				}
 				else {
-					outputRouter(num2Text(target.nipplesPerBreast) + " " + num2Text(int(target.nippleLength(temp)*10)/10) + "-inch " + plural(target.nippleDescript(temp)) + " ");
+					outputRouter(num2Text(target.nipplesPerBreast) + " " + UnitSystem.displayInchWithHyphenTextually(target.nippleLength(temp)) + " " + plural(target.nippleDescript(temp)) + " ");
 					if(target.breastRows[temp].breastRating() < 1) outputRouter("on each side.");
 					else outputRouter("each.");
 				}
 				if(target.breastRows[temp].nippleType == GLOBAL.NIPPLE_TYPE_DICK) {
-					outputRouter(" " + (target == pc ? "You":"[target.HeShe]") + " can make " + num2Text(Math.round(target.nippleLength(temp) * target.dickNippleMultiplier * 10)/10) + "-inch " + target.nippleCocksDescript(true) + " slide out from behind the " + target.areolaeDescript(temp, true) + ".");
+					outputRouter(" " + (target == pc ? "You":"[target.HeShe]") + " can make " + UnitSystem.displayInchWithHyphenTextually(target.nippleLength(temp) * target.dickNippleMultiplier) + " " + target.nippleCocksDescript(true) + " slide out from behind the " + target.areolaeDescript(temp, true) + ".");
 				}
 			}
 			//Inverted type
@@ -3627,7 +3625,7 @@ public function boobStuff(forTarget:Creature = null):void
 						outputRouter(" There isn’t any actual nub to the nipples - just " + target.areolaeDescript(temp, true) + ".");
 						break;
 					case GLOBAL.NIPPLE_TYPE_INVERTED:
-						outputRouter(" When you’re aroused enough, the " + num2Text(int(target.nippleLength(0)*10)/10) + "-inch nubs pop out, ready to play.");
+						outputRouter(" When you’re aroused enough, the " + UnitSystem.displayInchWithHyphenTextually(target.nippleLength(0)) + " nubs pop out, ready to play.");
 						break;
 					case GLOBAL.NIPPLE_TYPE_TENTACLED:
 						outputRouter(" They hide several long, prehensile tentacles, eager for an orifice to pleasure.");
@@ -3765,12 +3763,9 @@ public function crotchStuff(forTarget:Creature = null):void
 		
 		//SINGLE DICKS!
 		if(target.cockTotal() == 1) {
-			outputRouter((target == pc ? "Your":"[target.HisHer]") + " " + target.simpleCockNoun(0) + " is " + Math.floor(10*target.cocks[0].cLength())/10 + " inches long and ");
-			if(Math.floor(10*target.cocks[0].thickness())/10 < 2) {
-				if(Math.floor(10*target.cocks[0].thickness())/10 == 1) outputRouter(int(10*target.cocks[0].thickness())/10 + " inch thick");
-				else outputRouter(Math.round(10*target.cocks[0].thickness())/10 + " inches across");
-			}
-			else outputRouter(num2Text(Math.round(10*target.cocks[0].thickness())/10) + " inches across");
+			outputRouter((target == pc ? "Your":"[target.HisHer]") + " " + target.simpleCockNoun(0) + " is " + UnitSystem.displayInches(target.cocks[0].cLength()) + " long and ");
+			if(Math.floor(10*target.cocks[0].thickness())/10 == 1) outputRouter(UnitSystem.displayInches(1) + " thick");
+			else outputRouter(UnitSystem.displayInchesTextually(target.cocks[0].thickness()) + " across");
 			if(target.cocks[0].flaccidMultiplier != 1 && target.lust() < 100) outputRouter(" when fully erect");
 			outputRouter(".");
 			dickBonusForAppearance(forTarget, 0);
@@ -3793,46 +3788,32 @@ public function crotchStuff(forTarget:Creature = null):void
 					else outputRouter("\n" + (target == pc ? "Your":"[target.HisHer]") + " next ");
 					outputRouter(target.simpleCockNoun(temp));
 					outputRouter(" is ");
-					outputRouter(int(10*target.cocks[temp].cLength())/10 + " inches long and ");
-					if(Math.floor(target.cocks[temp].thickness()) >= 2) outputRouter(num2Text(Math.round(target.cocks[temp].thickness() * 10)/10) + " inches wide");
-					else {
-						if(target.cocks[temp].thickness() == 1) outputRouter("one inch wide");
-						else outputRouter(Math.round(target.cocks[temp].thickness()*10)/10 + " inches wide");
-					}
+					outputRouter(UnitSystem.displayInches(target.cocks[temp].cLength()) + " long and ");
+					outputRouter(UnitSystem.displayInchesTextually(target.cocks[temp].thickness()) + " wide");
 					if(target.cocks[temp].flaccidMultiplier != 1 && target.lust() < 100) outputRouter(" when fully erect");
 					outputRouter(".");
 				}
 				if(rando == 1) {
 					outputRouter("\n" + (target == pc ? "Your":"[target.HisHer]") + " " + num2Ordinal(temp + 1) + " ");
-					outputRouter(target.simpleCockNoun(temp) + " is " + Math.round(10*target.cocks[temp].cLength())/10 + " inches long and ");
-					if(Math.floor(target.cocks[temp].thickness()) >= 2) outputRouter(num2Text(Math.round(target.cocks[temp].thickness() * 10)/10) + " inches thick");
-					else {
-						if(target.cocks[temp].thickness() == 1) outputRouter("one-inch thick");
-						else outputRouter(Math.round(target.cocks[temp].thickness()*10)/10 + " inches thick");
-					}
+					outputRouter(target.simpleCockNoun(temp) + " is " + UnitSystem.displayInches(target.cocks[temp].cLength()) + " long and ");
+					if(target.cocks[temp].thickness() == 1) outputRouter(UnitSystem.displayInchWithHyphenTextually(1) + " thick");
+					else outputRouter(UnitSystem.displayInchesTextually(target.cocks[temp].thickness()) + " thick");
 					if(target.cocks[temp].flaccidMultiplier != 1 && target.lust() < 100) outputRouter(" when fully erect");
 					outputRouter(".");
 				}
 				if(rando == 2) {
 					outputRouter("\nThe " + num2Ordinal(temp + 1) + " ");
-					outputRouter(target.simpleCockNoun(temp) + " is " + Math.round(10*target.cocks[temp].cLength())/10 + " inches long and ");
-					if(Math.floor(target.cocks[temp].thickness()) >= 2) outputRouter(num2Text(Math.round(target.cocks[temp].thickness() * 10)/10) + " inches thick");
-					else {
-						if(target.cocks[temp].thickness() == 1) outputRouter("one-inch thick");
-						else outputRouter(Math.round(target.cocks[temp].thickness()*10)/10 + " inches thick");
-					}
+					outputRouter(target.simpleCockNoun(temp) + " is " + UnitSystem.displayInches(target.cocks[temp].cLength()) + " long and ");
+					if(target.cocks[temp].thickness() == 1) outputRouter(UnitSystem.displayInchWithHyphenTextually(1) + " thick");
+					else outputRouter(UnitSystem.displayInchesTextually(target.cocks[temp].thickness()) + " thick");
 					if(target.cocks[temp].flaccidMultiplier != 1 && target.lust() < 100) outputRouter(" when fully erect");
 					outputRouter(".");
 				}
 				if(rando == 3) {
 					if(temp > 0) outputRouter("\n" + (target == pc ? "Your":"[target.HisHer]") + " next ");
 					else outputRouter("\n" + (target == pc ? "Your":"[target.HisHer]") + " first ");
-					outputRouter(target.simpleCockNoun(temp) + " is " + Math.round(10*target.cocks[temp].cLength())/10 + " inches long and ");
-					if(Math.floor(target.cocks[temp].thickness()) >= 2) outputRouter(num2Text(Math.round(target.cocks[temp].thickness() * 10)/10) + " inches in diameter");
-					else {
-						if(Math.round(target.cocks[temp].thickness()*10)/10 == 1) outputRouter("one inch in diameter");
-						else outputRouter(Math.round(target.cocks[temp].thickness()*10)/10 + " inches in diameter");
-					}
+					outputRouter(target.simpleCockNoun(temp) + " is " + UnitSystem.displayInches(target.cocks[temp].cLength()) + " long and ");
+					outputRouter(UnitSystem.displayInchesTextually(target.cocks[temp].thickness()) + " in diameter");
 					if(target.cocks[temp].flaccidMultiplier != 1 && target.lust() < 100) outputRouter(" when fully erect");
 					outputRouter(".");
 				}
@@ -3893,16 +3874,13 @@ public function crotchStuff(forTarget:Creature = null):void
 		//Does it mention the dick at the end of the sentence? If so, dont use pronoun here:
 		if(target.hasCock() && !target.hasStatusEffect("Uniball"))
 		{
-			if(target.balls == 1) sBallsackDesc += " You estimate the testicle to be about " + num2Text(Math.round(ballSize)) + " ";
-			else sBallsackDesc += " You estimate each testicle to be about " + num2Text(Math.round(ballSize)) + " ";
+			if(target.balls == 1) sBallsackDesc += " You estimate the testicle to be about " + UnitSystem.displayInchesTextually(ballSize, 0);
+			else sBallsackDesc += " You estimate each testicle to be about " + UnitSystem.displayInchesTextually(ballSize, 0);
 		}
 		//No dick mention? Great! Pronouns deployed!
-		else if(target.balls == 1) sBallsackDesc += " You estimate it to be about " + num2Text(Math.round(ballSize)) + " ";
-		else sBallsackDesc += " You estimate each of them to be about " + num2Text(Math.round(ballSize)) + " ";
-		if(Math.round(ballSize) == 1) sBallsackDesc += "inch";
-		else sBallsackDesc += "inches";
-		var ballDisplayDiameter:Number = Math.round(target.ballDiameter()*10)/10;
-		sBallsackDesc += " around and " + ballDisplayDiameter + (ballDisplayDiameter != 1 ? " inches" : " inch") + " across.";
+		else if(target.balls == 1) sBallsackDesc += " You estimate it to be about " + UnitSystem.displayInchesTextually(ballSize, 0);
+		else sBallsackDesc += " You estimate each of them to be about " + UnitSystem.displayInchesTextually(ballSize, 0);
+		sBallsackDesc += " around and " + UnitSystem.displayInches(target.ballDiameter()) + " across.";
 		//Vanaeballs
 		if(target.statusEffectv4("Vanae Markings") > 0) sBallsackDesc += " Flowing across the surface of " + (target == pc ? "your":"[target.hisHer]") + " nutsack are intricate markings that glow " + target.skinAccent + ", softly pulsing with life.";
 		
@@ -3926,7 +3904,7 @@ public function crotchStuff(forTarget:Creature = null):void
 		if(target.vaginaTotal() == 1) {
 			vagSwellBonus = target.vaginalPuffiness(0);
 			
-			outputRouter((target == pc ? "You have":"[target.HeShe] has") + " " + indefiniteArticle(target.vaginaDescript(0,false,false,true)) + ", with " + num2Text(target.vaginas[0].clits) + " " + Math.round(target.clitLength*10)/10 + "-inch clit");
+			outputRouter((target == pc ? "You have":"[target.HeShe] has") + " " + indefiniteArticle(target.vaginaDescript(0,false,false,true)) + ", with " + num2Text(target.vaginas[0].clits) + " " + UnitSystem.displayInchWithHyphen(target.clitLength) + " clit");
 			if(target.vaginas[0].clits > 1) outputRouter("s");
 			if(target.vaginas[0].hymen) outputRouter(" and an intact hymen");
 			outputRouter(". ");
@@ -4033,7 +4011,7 @@ public function crotchStuff(forTarget:Creature = null):void
 				if(temp == 0) outputRouter("\n" + (target == pc ? "Your":"[target.HisHer]") + " first entrance");
 				else if(temp == 1) outputRouter("\nThe second slit");
 				else outputRouter("\nThe third and final vagina");
-				outputRouter(" is " + indefiniteArticle(target.vaginaDescript(temp,false,false,true)) + " with " + num2Text(target.vaginas[temp].clits) + " " + int(target.clitLength*10)/10 + "-inch clit");
+				outputRouter(" is " + indefiniteArticle(target.vaginaDescript(temp,false,false,true)) + " with " + num2Text(target.vaginas[temp].clits) + " " + UnitSystem.displayInchWithHyphen(target.clitLength) + " clit");
 				if(target.vaginas[temp].clits > 1) outputRouter("s");
 				//Virginal trumps all else
 				if(target.vaginas[temp].hymen) outputRouter(", still virginal in appearance.");
@@ -4584,7 +4562,7 @@ public function dickBonusForAppearance(forTarget:Creature = null, x:int = 0):voi
 			else outputRouter(" The obscenely swollen lump of flesh near the base of " + (target == pc ? "your":"[target.hisHer]") + " " + target.cockDescript(x) + " looks almost too big for " + (target == pc ? "your":"[target.hisHer]") + " cock.");
 		}
 		//List thickness
-		outputRouter(" The knot is " + Math.round(target.cocks[x].thickness() * target.cocks[x].knotMultiplier * 10)/10 + " inches wide" + (target.cocks[x].cType != GLOBAL.TYPE_DRACONIC ? " when at full size" : ", even when " + (target == pc ? "you’re":"[target.heShe]’s") + " not aroused") + ".");
+		outputRouter(" The knot is " + UnitSystem.displayInches(target.cocks[x].thickness() * target.cocks[x].knotMultiplier) + " wide" + (target.cocks[x].cType != GLOBAL.TYPE_DRACONIC ? " when at full size" : ", even when " + (target == pc ? "you’re":"[target.heShe]’s") + " not aroused") + ".");
 		//Appended to knot texts!
 		if(target.cocks[x].cType == GLOBAL.TYPE_KUITAN)
 		{

--- a/includes/creation.as
+++ b/includes/creation.as
@@ -607,10 +607,10 @@ public function chooseHeight():void {
 	output("<i> child, then? Very well. How tall should [pc.heShe] grow up to be? Please, give it in Imperial inches.”</i>");
 	output("\n\nVictor raises an eyebrow and quips, <i>“Seriously? Inches? What is this, the 20th century?”</i>");
 	output("\n\n<i>“Victor, I’ve known you for eighty years. We both know you’re a sucker for the classics. Don’t pretend you don’t use that archaic system just to screw with your acquaintances.”</i> The doctor smiles and continues, <i>“Now, the height?”</i>");
-	output("\n\n<b>Please give your character’s height in inches. For reference, 72 inches is about six feet tall or 182 centimeters.</b>");
+	output("\n\n<b>Please give your character’s height in " + UnitSystem.literalInches() + ", between " + UnitSystem.displayHeightInInches(raceHeightMin(pc.originalRace)) + " and " + UnitSystem.displayHeightInInches(raceHeightMax(pc.originalRace)) + "." + (UnitSystem.isSI() ? "" : " For reference, 72 inches is about six feet tall.</b>"));
 	
 	displayInput();
-	userInterface.textInput.text = String(averageHeight());
+	userInterface.textInput.text = String(formatFloat(UnitSystem.lengthInInches(averageHeight()), 0));
 	output("\n\n\n");
 	//[Height Box]
 	clearMenu();
@@ -674,15 +674,15 @@ public function applyHeight(confirm:Boolean = false):void {
 	
 	// Non-number and over-limit fails
 	if(isNaN(Number(userInterface.textInput.text))) {
-		output("Choose a height using numbers only, please. And remember, the value should be given in inches.");
+		output("Choose a height using numbers only, please. And remember, the value should be given in " + UnitSystem.literalInches() + ".");
 		fail = true;
 	}
-	else if(Number(userInterface.textInput.text) < heightMin) {
-		output("Choose a height at or above " + heightMin + " inches tall, please.");
+	else if(Number(userInterface.textInput.text) < UnitSystem.lengthInInches(heightMin)) {
+		output("Choose a height at or above " + UnitSystem.displayHeightInInches(heightMin) + " tall, please.");
 		fail = true;
 	}
-	else if(Number(userInterface.textInput.text) > heightMax) {
-		output("Choose a height at or below " + heightMax + " inches tall, please.");
+	else if(Number(userInterface.textInput.text) > UnitSystem.lengthInInches(heightMax)) {
+		output("Choose a height at or below " + UnitSystem.displayHeightInInches(heightMax) + " tall, please.");
 		fail = true;
 	}
 	if(fail) {
@@ -696,7 +696,8 @@ public function applyHeight(confirm:Boolean = false):void {
 	}
 	
 	if(confirm) {
-		pc.tallness = Number(userInterface.textInput.text);
+		var tallness:Number = Number(userInterface.textInput.text);
+		pc.tallness = UnitSystem.isSI() ? UnitSystem.centimeterToInch(tallness) : tallness;
 		if(stage.contains(userInterface.textInput)) 
 			removeInput();
 		chooseThickness();
@@ -705,29 +706,27 @@ public function applyHeight(confirm:Boolean = false):void {
 	
 	var stringInput:String = userInterface.textInput.text;
 	var newTallness:Number = Number(stringInput);
-	var newFeet:Number = Math.floor(newTallness/12);
-	var newInches:Number = (Math.round((newTallness - (newFeet * 12)) * 1000)/1000);
-	var newCentimeters:Number = (newTallness * 2.54);
-	var newMeters:Number = (newCentimeters)/100;
 	
-	output("You chose " + newTallness + " inch" + (newTallness == 1 ? "" : "es"));
-	if(newTallness >= 12)
-	{
-		output(" (");
-		if(newFeet > 0)
-		{
-			output(newFeet + " f" + (newFeet == 1 ? "oo" : "ee") + "t");
-			if(newInches > 0) output(" and ");
-		}
-		if(newInches > 0) output(newInches + " inch" + (newInches == 1 ? "" : "es"));
-		output(")");
+	output("You chose ");
+	if (UnitSystem.isSI()) {
+		 output(newTallness + " centimeters");
 	}
-	if(newCentimeters >= 0)
-	{
-		output(", or " + (Math.round(newCentimeters * 1000)/1000) + " centimeters");
-		if(newMeters >= 0)
+	else {
+		var newFeet:Number = Math.floor(newTallness/12);
+		var newInches:Number = (Math.round((newTallness - (newFeet * 12)) * 1000)/1000);
+
+		output(newTallness + " inches");
+
+		if(newTallness >= 12)
 		{
-			output(" (" + (Math.round(newMeters * 1000)/1000) + " meters)");
+			output(" (");
+			if(newFeet > 0)
+			{
+				output(newFeet + " f" + (newFeet == 1 ? "oo" : "ee") + "t");
+				if(newInches > 0) output(" and ");
+			}
+			if(newInches > 0) output(newInches + " inch" + (newInches == 1 ? "" : "es"));
+			output(")");
 		}
 	}
 	output(". Is this correct? If not, input a new value to retry.");
@@ -1220,15 +1219,15 @@ public function chooseYourJunkSize():void {
 		case "half-suula": cLengths = [10, 11, 12, 13, 14]; break;
 	}
 	
-	output(num2Text(cLengths[0]) + " to " + num2Text(cLengths[cLengths.length - 1]));
+	output(num2Text(UnitSystem.lengthInInches(cLengths[0])) + " to " + num2Text(UnitSystem.lengthInInches(cLengths[cLengths.length - 1])));
 	
 	for (i = 0; i < cLengths.length; i++)
 	{
-		addButton(i, (String(cLengths[i]) + "\""), applyJunkSize, cLengths[i]);
+		addButton(i, UnitSystem.displayLengthInInchesShort2(cLengths[i]), applyJunkSize, cLengths[i]);
 	}
 	addButton(13,"Whatever",applyJunkSize,cLengths[rand(cLengths.length)]);
 	
-	output(" inches. How long do you want it?”</i>");
+	output(" " + UnitSystem.literalInches() + ". How long do you want it?”</i>");
 	if(cLengths[cLengths.length - 1] >= 9) output(" He rolls his eyes. <i>“You’re gonna make your kid a stallion here, aren’t you? Why do I even ask?”</i>");
 	
 	//NEW (cont.)
@@ -2048,7 +2047,7 @@ public function takeCelise():void {
 		output("\n\nYour " + pc.legOrLegs() + " wobble");
 		if(pc.legCount == 1) output("s");
 		output(" from the sensation assaulting you, and you grab hold of the shelf for support, watching the emerald blob slide across the floor until it squishes up against you. Celise gushes, <i>“Ohh, look at it! It’s nice and hard and veiny and it tastes so good inside me! Thank you for deigning to feed me... " + pc.short + ", was it?”</i>");
-		output("\n\nYou nod and try to stay upright. Fluid weight roils around your " + pc.cockDescript(x) + " with slow, gentle undulations, tickling every square inch of its surface with perfect pressure. Somehow, despite its glorious slipperiness, there’s just enough friction for your body to make your nerves fire one after the other, forcing your internal muscles to flutter and squeeze fat drops of pre-cum into the goo-girl’s wrist. She arches her back to raise her titanic breasts into her arm, absorbing her own elbow, forearm, and then wrist, drawing your dick deep into her swollen teat. You gasp and drip a bit more freely in response.");
+		output("\n\nYou nod and try to stay upright. Fluid weight roils around your " + pc.cockDescript(x) + " with slow, gentle undulations, tickling every square " + UnitSystem.literalInch() + " of its surface with perfect pressure. Somehow, despite its glorious slipperiness, there’s just enough friction for your body to make your nerves fire one after the other, forcing your internal muscles to flutter and squeeze fat drops of pre-cum into the goo-girl’s wrist. She arches her back to raise her titanic breasts into her arm, absorbing her own elbow, forearm, and then wrist, drawing your dick deep into her swollen teat. You gasp and drip a bit more freely in response.");
 		output("\n\n<i>“Yum! Even your pre-cum is tasty. Can I just keep milking that out of you, or would you rather I get you off? Unless you can cum hard enough to make my tit turn white, I think I’d prefer the former,”</i> Celise giggles as her arm exits out the bottom of her tit, appearing to hold it up, though it’s made of the same material as the jiggling, gelatinous mammary. Her free hand is buried to the wrist in her gooey undercarriage, pumping low and slow into a massive, over-engorged honeypot.");
 		output("\n\nYou grunt in pleasure and pain as your ardor builds to an unmanageable boil, aching to burst out, to explode deep into Celise’s gooey, delicious tit. Her controlled motions seem intent on holding you there forever. She teases you to the precipice and backs off again and again, devouring the hot, liquid pleasure that " + pc.eachCock() + " releases whenever you get particularly close. You can’t take it anymore!");
 		output("\n\nLetting go of the shelf, you grab hold of her massive tit in both hands");

--- a/includes/creation.as
+++ b/includes/creation.as
@@ -1223,7 +1223,7 @@ public function chooseYourJunkSize():void {
 	
 	for (i = 0; i < cLengths.length; i++)
 	{
-		addButton(i, UnitSystem.displayLengthInInchesShort2(cLengths[i]), applyJunkSize, cLengths[i]);
+		addButton(i, UnitSystem.displayInchesShort2(cLengths[i]), applyJunkSize, cLengths[i]);
 	}
 	addButton(13,"Whatever",applyJunkSize,cLengths[rand(cLengths.length)]);
 	

--- a/includes/gameStats.as
+++ b/includes/gameStats.as
@@ -64,8 +64,8 @@ public function statisticsScreen(showID:String = "All"):void
 			output2("\n<b>* Current Race:</b> " + StringUtil.toTitleCase(pc.race()));
 		}
 		else output2("\n<b>* Race:</b> " + StringUtil.toTitleCase(pc.originalRace));
-		output2("\n<b>* Height:</b> " + prettifyLength(pc.tallness));
-		output2("\n<b>* Weight:</b> " + prettifyWeight(pc.fullBodyWeight()));
+		output2("\n<b>* Height:</b> " + UnitSystem.displayPreciseLengthShort2(pc.tallness));
+		output2("\n<b>* Weight:</b> " + UnitSystem.displayWeightShort(pc.fullBodyWeight()));
 		output2("\n<b>* Sex:</b> ");
 		if(pc.genderTextOverride() != "") output2(pc.genderTextOverride());
 		else if(pc.hasCock() && !pc.hasVagina()) output2("Male");
@@ -108,7 +108,7 @@ public function statisticsScreen(showID:String = "All"):void
 		if(exposureVisible > 0) output2(", " + exposureVisible + " Visible");
 		if(exposurePhysical > 0) output2(", " + exposurePhysical + " Exposed");
 		output2("\n<b>* Exhibitionism:</b> " + formatFloat(pc.exhibitionism(), 1) + "/100");
-		output2("\n<b>* Carry Threshold:</b> " + prettifyWeight(pc.bodyStrength()));
+		output2("\n<b>* Carry Threshold:</b> " + UnitSystem.displayWeightShort(pc.bodyStrength()));
 		//if(pc.weightQ("full") > 0) output2(" (" + pc.weightQ("full") + " %)");
 		// Head
 		output2("\n<b><u>Head</u></b>");
@@ -129,7 +129,7 @@ public function statisticsScreen(showID:String = "All"):void
 			output2("\n<b>* Beard, Length:</b>");
 			if(pc.beardLength > 0.125)
 			{
-				output2(" " + prettifyLength(pc.beardLength));
+				output2(" " + UnitSystem.displayPreciseLengthShort2(pc.beardLength));
 				if(pc.beardStyle != 0) output2("\n<b>* Beard, Style:</b> " + StringUtil.toDisplayCase(pc.beardStyles()));
 			}
 			else if(pc.skinType == GLOBAL.SKIN_TYPE_FUR) output2(" Short, Fur");
@@ -147,7 +147,7 @@ public function statisticsScreen(showID:String = "All"):void
 			output2("\n<b>* Hair, Length:</b>");
 			if(pc.hairLength > 0.125)
 			{
-				output2(" " + prettifyLength(pc.hairLength));
+				output2(" " + UnitSystem.displayPreciseLengthShort2(pc.hairLength));
 				if(pc.hairStyle != "null") output2("\n<b>* Hair, Style:</b> " + StringUtil.toDisplayCase(pc.hairStyle));
 			}
 			else output2(" Shaved");
@@ -156,7 +156,7 @@ public function statisticsScreen(showID:String = "All"):void
 		else output2(" None");
 		if(pc.hasAntennae()) output2("\n<b>* Antennae:</b> " + pc.antennae + ", " + GLOBAL.TYPE_NAMES[pc.antennaeType]);
 		output2("\n<b>* Ears:</b>");
-		if(pc.hasLongEars()) output2(" " + prettifyLength(pc.earLength) + ",");
+		if(pc.hasLongEars()) output2(" " + UnitSystem.displayPreciseLengthShort2(pc.earLength) + ",");
 		if(pc.earFlags.length > 0)
 		{
 			for(i = 0; i < pc.earFlags.length; i++)
@@ -198,11 +198,11 @@ public function statisticsScreen(showID:String = "All"):void
 			if(pc.hasStatusEffect("Horn Bumps")) output2(" Horn Bumps");
 			else
 			{
-				if(InCollection(pc.hornType, GLOBAL.TYPE_DEER, GLOBAL.TYPE_DRYAD)) output2(" 2, " + prettifyLength(pc.hornLength) + ", " + GLOBAL.TYPE_NAMES[pc.hornType] + ", " + pc.horns + " Points");
+				if(InCollection(pc.hornType, GLOBAL.TYPE_DEER, GLOBAL.TYPE_DRYAD)) output2(" 2, " + UnitSystem.displayPreciseLengthShort2(pc.hornLength) + ", " + GLOBAL.TYPE_NAMES[pc.hornType] + ", " + pc.horns + " Points");
 				else
 				{
 					output2(" " + pc.horns + ",");
-					if(pc.hornLength > 0) output2(" " + prettifyLength(pc.hornLength) + ",");
+					if(pc.hornLength > 0) output2(" " + UnitSystem.displayPreciseLengthShort2(pc.hornLength) + ",");
 					output2(" " + GLOBAL.TYPE_NAMES[pc.hornType]);
 				}
 			}
@@ -290,8 +290,8 @@ public function statisticsScreen(showID:String = "All"):void
 			output2(GLOBAL.TYPE_NAMES[pc.tailGenitalArg]);
 			if(pc.hasTailCock()) output2(", " + GLOBAL.TAIL_GENTIAL_TYPE_NAMES[1]);
 			if(pc.hasTailCunt()) output2(", " + GLOBAL.TAIL_GENTIAL_TYPE_NAMES[2]);
-			if(pc.hasTailCock()) output2("\n<b>* Tail, Genital Volume:</b> " + prettifyVolume(pc.tailCockVolume()));
-			if(pc.hasTailCunt()) output2("\n<b>* Tail, Genital Capacity:</b> " + prettifyVolume(pc.tailCuntCapacity()));
+			if(pc.hasTailCock()) output2("\n<b>* Tail, Genital Volume:</b> " + UnitSystem.displayVolumeShort(pc.tailCockVolume()));
+			if(pc.hasTailCunt()) output2("\n<b>* Tail, Genital Capacity:</b> " + UnitSystem.displayVolumeShort(pc.tailCuntCapacity()));
 		}
 		if(pc.hasGenitals())
 		{
@@ -313,7 +313,7 @@ public function statisticsScreen(showID:String = "All"):void
 			}
 			if(pc.breastRows.length > 1)
 			{
-				output2("\n<b>* Breasts, Weight:</b> " + prettifyWeight(pc.bodyPartWeight("breast")) + ", total");
+				output2("\n<b>* Breasts, Weight:</b> " + UnitSystem.displayWeightShort(pc.bodyPartWeight("breast")) + ", total");
 				if(pc.weightQ("breast") > 0) output2(" (" + pc.weightQ("breast") + " %)");
 			}
 			if(pc.hasNipples())
@@ -334,8 +334,8 @@ public function statisticsScreen(showID:String = "All"):void
 				output2("\n<b><u>Lactation</u></b>");
 				output2("\n<b>* Milk, Type:</b> " + GLOBAL.FLUID_TYPE_NAMES[pc.milkType]);
 				output2("\n<b>* Milk, Capacity:</b> " + formatFloat(pc.milkFullness, 1) + " %");
-				output2("\n<b>* Milk, Current" + ((pc.breastRows.length == 1) ? "" : ", Total") + ":</b> " + mLs(Math.round(pc.lactationQ(99))));
-				output2("\n<b>* Milk, Max" + ((pc.breastRows.length == 1) ? "" : ", Total") + ":</b> " + mLs(pc.milkCapacity(99)));
+				output2("\n<b>* Milk, Current" + ((pc.breastRows.length == 1) ? "" : ", Total") + ":</b> " + UnitSystem.displayLitersShort(Math.round(pc.lactationQ(99))));
+				output2("\n<b>* Milk, Max" + ((pc.breastRows.length == 1) ? "" : ", Total") + ":</b> " + UnitSystem.displayLitersShort(pc.milkCapacity(99)));
 				output2("\n<b>* Milk, Production Training:</b> " + formatFloat(pc.milkMultiplier, 1) + " %");
 				output2("\n<b>* Milk, Production Bonus:</b> " + Math.round(pc.milkRate*100)/10 + " %");
 			}
@@ -360,11 +360,11 @@ public function statisticsScreen(showID:String = "All"):void
 						if(pc.breastRows[x].breastRatingMod != 0 && pc.siliconeRating("tits") != 0) output2("\n<b>* Breast, Silicone Size Rating:</b> " + formatFloat(pc.siliconeRating("tits"), 3));
 						if(pc.breastRows[x].breastRatingHoneypotMod != 0) output2("\n<b>* Breast, Honeypot Size Rating:</b> " + formatFloat(pc.breastRows[x].breastRatingHoneypotMod, 3));
 						if(pc.breastRows[x].breastRatingLactationMod != 0) output2("\n<b>* Breast, Lactation Size Rating:</b> " + formatFloat(pc.breastRows[x].breastRatingLactationMod, 3));
-						output2("\n<b>* Breast Row, Weight:</b> " + prettifyWeight(pc.bodyPartWeight("breast", x)));
+						output2("\n<b>* Breast Row, Weight:</b> " + UnitSystem.displayWeightShort(pc.bodyPartWeight("breast", x)));
 						if(pc.weightQ("breast", x) > 0) output2(" (" + pc.weightQ("breast", x) + " %)");
 					}
 					output2("\n<b>* Areola:</b> " + " " + StringUtil.toDisplayCase(pc.areolaFlagDescript(x)));
-					output2("\n<b>* Areola, Size:</b> " + prettifyLength(pc.nippleWidth(x)));
+					output2("\n<b>* Areola, Size:</b> " + UnitSystem.displayPreciseLengthShort2(pc.nippleWidth(x)));
 					output2("\n<b>* Nipple, Type:</b> " + " " + GLOBAL.NIPPLE_TYPE_NAMES[pc.breastRows[x].nippleType]);
 					if(pc.breastRows[x].fuckable()) output2(", Fuckable");
 					if(pc.breastRows[x].nippleType == GLOBAL.NIPPLE_TYPE_DICK) output2("\n<b>* Nipple, Genital Type:</b> " + GLOBAL.TYPE_NAMES[pc.dickNippleType]);
@@ -372,18 +372,18 @@ public function statisticsScreen(showID:String = "All"):void
 					{
 						if(pc.breastRows[x].nippleType == GLOBAL.NIPPLE_TYPE_DICK)
 						{
-							output2("\n<b>* Nipple, Length, Flaccid:</b> " + prettifyLength(pc.nippleLength(0)));
-							output2("\n<b>* Nipple, Length, Erect:</b> " + prettifyLength(pc.nippleLength(0) * pc.dickNippleMultiplier));
+							output2("\n<b>* Nipple, Length, Flaccid:</b> " + UnitSystem.displayPreciseLengthShort2(pc.nippleLength(0)));
+							output2("\n<b>* Nipple, Length, Erect:</b> " + UnitSystem.displayPreciseLengthShort2(pc.nippleLength(0) * pc.dickNippleMultiplier));
 						}
-						else output2("\n<b>* Nipple, Length:</b> " + prettifyLength(pc.nippleLength(x)));
+						else output2("\n<b>* Nipple, Length:</b> " + UnitSystem.displayPreciseLengthShort2(pc.nippleLength(x)));
 						if(pc.breastRows[x].breasts != 1) output2(" each");
 					}
 					if(pc.hasPiercedNipples(x)) output2("\n<b>* Nipple Piercing:</b> " + StringUtil.toDisplayCase(pc.breastRows[x].piercing.longName));
 					if(pc.breastRows[x].breasts != 1) output2(" each");
 					if(pc.breastRows.length != 1)
 					{
-						output2("\n<b>* Milk, Current:</b> " + mLs(Math.round(pc.lactationQ(x))));
-						output2("\n<b>* Milk, Max:</b> " + mLs(pc.milkCapacity(x)));
+						output2("\n<b>* Milk, Current:</b> " + UnitSystem.displayLitersShort(Math.round(pc.lactationQ(x))));
+						output2("\n<b>* Milk, Max:</b> " + UnitSystem.displayLitersShort(pc.milkCapacity(x)));
 					}
 				}
 			}
@@ -403,8 +403,8 @@ public function statisticsScreen(showID:String = "All"):void
 			if(pc.balls <= 0)
 			{
 				//output2(", Prostate");
-				output2("\n<b>* Prostate, Volume:</b> " + prettifyVolume(pc.ballVolume(), 1));
-				output2("\n<b>* Prostate, Weight:</b> " + prettifyWeight(pc.bodyPartWeight("testicle")));
+				output2("\n<b>* Prostate, Volume:</b> " + UnitSystem.displayVolumeShort(pc.ballVolume()));
+				output2("\n<b>* Prostate, Weight:</b> " + UnitSystem.displayWeightShort(pc.bodyPartWeight("testicle")));
 				if(pc.weightQ("testicle") > 0) output2(" (" + pc.weightQ("testicle") + " %)");
 			}
 			else if(pc.balls > 0)
@@ -420,12 +420,12 @@ public function statisticsScreen(showID:String = "All"):void
 					if(pc.getStatusTooltip("Special Scrotum") != "") output2(", " + StringUtil.toDisplayCase(pc.getStatusTooltip("Special Scrotum")));
 				}
 				if(pc.statusEffectv4("Vanae Markings") > 0) output2(", " + StringUtil.toDisplayCase(pc.skinAccent) + " Markings");
-				output2("\n<b>* Testicle, Size:</b> " + prettifyLength(pc.ballDiameter()) + " across, " + prettifyLength(pc.ballSize()) + " around");
+				output2("\n<b>* Testicle, Size:</b> " + UnitSystem.displayPreciseLengthShort2(pc.ballDiameter()) + " across, " + UnitSystem.displayPreciseLengthShort2(pc.ballSize()) + " around");
 				if(pc.ballSizeMod != 1) output2(" (" + StringUtil.printPlusMinus(formatFloat(pc.ballSizeMod, 3)) + ")");
 				if(pc.balls != 1) output2(", each");
-				output2("\n<b>* Testicle, Volume:</b> " + prettifyVolume(pc.ballVolume(), 1));
+				output2("\n<b>* Testicle, Volume:</b> " + UnitSystem.displayVolumeShort(pc.ballVolume()));
 				if(pc.balls != 1) output2(", each");
-				output2("\n<b>* Testicle, Weight:</b> " + prettifyWeight(pc.bodyPartWeight("testicle")));
+				output2("\n<b>* Testicle, Weight:</b> " + UnitSystem.displayWeightShort(pc.bodyPartWeight("testicle")));
 				if(pc.balls != 1) output2(", total");
 				if(pc.weightQ("testicle") > 0) output2(" (" + pc.weightQ("testicle") + " %)");
 			}
@@ -434,7 +434,7 @@ public function statisticsScreen(showID:String = "All"):void
 			else output2(" Taken");
 			if(pc.cocks.length > 1)
 			{
-				output2("\n<b>* Penis, Weight:</b> " + prettifyWeight(pc.bodyPartWeight("penis")));
+				output2("\n<b>* Penis, Weight:</b> " + UnitSystem.displayWeightShort(pc.bodyPartWeight("penis")));
 				if(pc.cocks.length > 1) output2(", total");
 				if(pc.weightQ("penis") > 0) output2(" (" + pc.weightQ("penis") + " %)");
 			}
@@ -444,9 +444,9 @@ public function statisticsScreen(showID:String = "All"):void
 			if(pc.ballSizeRaw > 0 && pc.perkv1("'Nuki Nuts") > 0) output2(" " + formatFloat(pc.ballFullness + ((pc.perkv1("'Nuki Nuts")/pc.ballSizeRaw) * 100), 1) + " %");
 			else output2(" " + formatFloat(pc.ballFullness, 1) + " %");
 			output2("\n<b>* Cum, Quantity Modifier:</b> " + Math.round(pc.cumMultiplier()*1000)/10 + " %");
-			output2("\n<b>* Cum, Current Internal:</b> " + mLs(pc.currentCum()));
-			output2("\n<b>* Cum, Probable Ejaculation:</b> " + mLs(Math.round(pc.cumQ())));
-			output2("\n<b>* Cum, Max:</b> " + mLs(pc.maxCum()));
+			output2("\n<b>* Cum, Current Internal:</b> " + UnitSystem.displayLitersShort(pc.currentCum()));
+			output2("\n<b>* Cum, Probable Ejaculation:</b> " + UnitSystem.displayLitersShort(Math.round(pc.cumQ())));
+			output2("\n<b>* Cum, Max:</b> " + UnitSystem.displayLitersShort(pc.maxCum()));
 			output2("\n<b>* Refractory Rate:</b> " + Math.round(pc.refractoryRate*1000)/10 + " %");
 			if(pc.virility() <= 0) output2("\n<b>* Virility:</b> Infertile");
 			else
@@ -471,25 +471,25 @@ public function statisticsScreen(showID:String = "All"):void
 					}
 					if(pc.cocks[x].cockColor != "") output2(" " + StringUtil.toDisplayCase(pc.cocks[x].cockColor) + ",");
 					output2(" " + GLOBAL.TYPE_NAMES[pc.cocks[x].cType]);
-					output2("\n<b>* Length, Flaccid:</b> " + prettifyLength(pc.cLengthFlaccid(x)));
-					output2("\n<b>* Length, Current:</b> " + prettifyLength(pc.cLengthFlaccid(x, true)));
-					output2("\n<b>* Length, Erect:</b> " + prettifyLength(pc.cLength(x)));
-					output2("\n<b>* Thickness:</b> " + prettifyLength(pc.cThickness(x)));
+					output2("\n<b>* Length, Flaccid:</b> " + UnitSystem.displayPreciseLengthShort2(pc.cLengthFlaccid(x)));
+					output2("\n<b>* Length, Current:</b> " + UnitSystem.displayPreciseLengthShort2(pc.cLengthFlaccid(x, true)));
+					output2("\n<b>* Length, Erect:</b> " + UnitSystem.displayPreciseLengthShort2(pc.cLength(x)));
+					output2("\n<b>* Thickness:</b> " + UnitSystem.displayPreciseLengthShort2(pc.cThickness(x)));
 					output2("\n<b>* Thickness, Ratio Modifier:</b> " + Math.round(pc.cocks[x].cThicknessRatio()*1000)/10 + " %");
-					output2("\n<b>* Girth:</b> " + prettifyLength(pc.cGirth(x)));
+					output2("\n<b>* Girth:</b> " + UnitSystem.displayPreciseLengthShort2(pc.cGirth(x)));
 					if(pc.hasKnot(x))
 					{
-						output2("\n<b>* Knot Thickness:</b> " + prettifyLength(pc.knotThickness(x)));
-						output2("\n<b>* Knot Girth:</b> " + prettifyLength(pc.knotGirth(x)));
+						output2("\n<b>* Knot Thickness:</b> " + UnitSystem.displayPreciseLengthShort2(pc.knotThickness(x)));
+						output2("\n<b>* Knot Girth:</b> " + UnitSystem.displayPreciseLengthShort2(pc.knotGirth(x)));
 					}
 					if(pc.cockVolume(x, false) != pc.cockVolume(x))
 					{
-						output2("\n<b>* Volume, Physical:</b> " + prettifyVolume(pc.cockVolume(x, false)));
-						output2("\n<b>* Volume, Effective:</b> " + prettifyVolume(pc.cockVolume(x)));
+						output2("\n<b>* Volume, Physical:</b> " + UnitSystem.displayVolumeShort(pc.cockVolume(x, false)));
+						output2("\n<b>* Volume, Effective:</b> " + UnitSystem.displayVolumeShort(pc.cockVolume(x)));
 					}
-					else output2("\n<b>* Volume:</b> " + prettifyVolume(pc.cockVolume(x)));
-					output2("\n<b>* Capacity:</b> " + prettifyVolume(pc.cockCapacity(x)));
-					output2("\n<b>* Weight:</b> " + prettifyWeight(pc.bodyPartWeight("penis", x)));
+					else output2("\n<b>* Volume:</b> " + UnitSystem.displayVolumeShort(pc.cockVolume(x)));
+					output2("\n<b>* Capacity:</b> " + UnitSystem.displayVolumeShort(pc.cockCapacity(x)));
+					output2("\n<b>* Weight:</b> " + UnitSystem.displayWeightShort(pc.bodyPartWeight("penis", x)));
 					if(pc.weightQ("penis", x) > 0) output2(" (" + pc.weightQ("penis", x) + " %)");
 					if(pc.hasCockPiercing(x)) output2("\n<b>* Piercing:</b> " + StringUtil.toDisplayCase(pc.cocks[x].piercing.longName));
 					if(pc.hasCocksock(x)) output2("\n<b>* Sock:</b> " + StringUtil.toDisplayCase(pc.cocks[x].cocksock.longName));
@@ -512,11 +512,11 @@ public function statisticsScreen(showID:String = "All"):void
 				//if(pc.vaginas.length != 0) output2(",");
 				//output2(" " + pc.totalClits() +" Clit");
 				//if(pc.totalClits() != 1) output2("s");
-				if(pc.clitLength != 0) output2("\n<b>* Clitoris, Length:</b> " + prettifyLength(pc.clitLength));
+				if(pc.clitLength != 0) output2("\n<b>* Clitoris, Length:</b> " + UnitSystem.displayPreciseLengthShort2(pc.clitLength));
 				if(pc.totalClits() != 1) output2(", each");
 				if(pc.vaginas.length > 1)
 				{
-					output2("\n<b>* Clitoris, Weight:</b> " + prettifyWeight(pc.bodyPartWeight("clitoris")));
+					output2("\n<b>* Clitoris, Weight:</b> " + UnitSystem.displayWeightShort(pc.bodyPartWeight("clitoris")));
 					if(pc.totalClits() != 1) output2(", total");
 					if(pc.weightQ("clitoris") > 0) output2(" (" + pc.weightQ("clitoris") + " %)");
 				}
@@ -527,7 +527,7 @@ public function statisticsScreen(showID:String = "All"):void
 			// Girlcum Stats
 			output2("\n<b>* Girlcum, Type:</b> " + GLOBAL.FLUID_TYPE_NAMES[pc.girlCumType]);
 			output2("\n<b>* Girlcum, Quantity Modifier:</b> " + Math.round(pc.girlCumMultiplier()*1000)/10 + " %");
-			output2("\n<b>* Girlcum, Probable Ejaculation:</b> " + mLs(pc.girlCumQ()));
+			output2("\n<b>* Girlcum, Probable Ejaculation:</b> " + UnitSystem.displayLitersShort(pc.girlCumQ()));
 			// Fertility
 			if(pc.fertility() <= 0) output2("\n<b>* Fertility:</b> Infertile");
 			else
@@ -558,11 +558,11 @@ public function statisticsScreen(showID:String = "All"):void
 					output2("\n<b>* Hymen:</b>");
 					if(pc.vaginas[x].hymen) output2(" Virgin");
 					else output2(" Taken");
-					if(pc.vaginas[x].bonusCapacity == 0) output2("\n<b>* Capacity:</b> " + prettifyVolume(pc.vaginalCapacity(x)));
+					if(pc.vaginas[x].bonusCapacity == 0) output2("\n<b>* Capacity:</b> " + UnitSystem.displayVolumeShort(pc.vaginalCapacity(x)));
 					else
 					{
-						output2("\n<b>* Capacity, Bonus:</b> " + prettifyVolume(pc.vaginas[x].bonusCapacity));
-						output2("\n<b>* Capacity, Effective:</b> " + prettifyVolume(pc.vaginalCapacity(x)));
+						output2("\n<b>* Capacity, Bonus:</b> " + UnitSystem.displayVolumeShort(pc.vaginas[x].bonusCapacity));
+						output2("\n<b>* Capacity, Effective:</b> " + UnitSystem.displayVolumeShort(pc.vaginalCapacity(x)));
 					}
 					output2("\n<b>* Looseness Level, Current:</b> " + formatFloat(pc.vaginas[x].looseness(), 3));
 					output2("\n<b>* Looseness Level, Minimum:</b> " + formatFloat(pc.vaginas[x].minLooseness, 3));
@@ -571,7 +571,7 @@ public function statisticsScreen(showID:String = "All"):void
 					if(pc.vaginas[x].clits > 0)
 					{
 						output2("\n<b>* Clitoris:</b> " + pc.vaginas[x].clits);
-						output2("\n<b>* Clitoris, Weight:</b> " + prettifyWeight(pc.bodyPartWeight("clitoris", x)));
+						output2("\n<b>* Clitoris, Weight:</b> " + UnitSystem.displayWeightShort(pc.bodyPartWeight("clitoris", x)));
 						if(pc.vaginas[x].clits != 1) output2(", total");
 						if(pc.weightQ("clitoris", x) > 0) output2(" (" + pc.weightQ("clitoris", x) + " %)");
 					}
@@ -602,12 +602,12 @@ public function statisticsScreen(showID:String = "All"):void
 		else output2("\n<b>* Belly, Size Rating:</b>");
 		output2(" " + formatFloat(pc.bellyRating(), 3));
 		if(pc.bellyRatingMod != 0) output2(" (" + StringUtil.printPlusMinus(formatFloat(pc.bellyRatingMod, 3)) + ")");
-		output2("\n<b>* Belly, Weight:</b> " + prettifyWeight(pc.bodyPartWeight("belly")));
+		output2("\n<b>* Belly, Weight:</b> " + UnitSystem.displayWeightShort(pc.bodyPartWeight("belly")));
 		if(pc.weightQ("belly") > 0) output2(" (" + pc.weightQ("belly") + " %)");
 		if(pc.hasBellyPiercing()) output2("\n<b>* Belly Piercing:</b> " + StringUtil.toDisplayCase(pc.bellyPiercing.longName));
-		if(pc.statusEffectv1("Orally-Filled") > 0) output2("\n<b>* Cumflation, Oral:</b> " + GLOBAL.FLUID_TYPE_NAMES[pc.statusEffectv3("Orally-Filled")] + ", " + mLs(Math.round(pc.statusEffectv1("Orally-Filled"))));
-		if(pc.statusEffectv1("Anally-Filled") > 0) output2("\n<b>* Cumflation, Anal:</b> " + GLOBAL.FLUID_TYPE_NAMES[pc.statusEffectv3("Anally-Filled")] + ", " + mLs(Math.round(pc.statusEffectv1("Anally-Filled"))));
-		if(pc.statusEffectv1("Vaginally-Filled") > 0) output2("\n<b>* Cumflation, Vaginal:</b> " + GLOBAL.FLUID_TYPE_NAMES[pc.statusEffectv3("Vaginally-Filled")] + ", " + mLs(Math.round(pc.statusEffectv1("Vaginally-Filled"))));
+		if(pc.statusEffectv1("Orally-Filled") > 0) output2("\n<b>* Cumflation, Oral:</b> " + GLOBAL.FLUID_TYPE_NAMES[pc.statusEffectv3("Orally-Filled")] + ", " + UnitSystem.displayLitersShort(Math.round(pc.statusEffectv1("Orally-Filled"))));
+		if(pc.statusEffectv1("Anally-Filled") > 0) output2("\n<b>* Cumflation, Anal:</b> " + GLOBAL.FLUID_TYPE_NAMES[pc.statusEffectv3("Anally-Filled")] + ", " + UnitSystem.displayLitersShort(Math.round(pc.statusEffectv1("Anally-Filled"))));
+		if(pc.statusEffectv1("Vaginally-Filled") > 0) output2("\n<b>* Cumflation, Vaginal:</b> " + GLOBAL.FLUID_TYPE_NAMES[pc.statusEffectv3("Vaginally-Filled")] + ", " + UnitSystem.displayLitersShort(Math.round(pc.statusEffectv1("Vaginally-Filled"))));
 		if(!pc.hasVagina() || pc.fertility() <= 0)
 		{
 			output2("\n<b>* Incubation, Speed Modifier:</b> " + Math.round(pc.pregnancyIncubationBonusMother()*1000)/10 + " %");
@@ -714,7 +714,7 @@ public function statisticsScreen(showID:String = "All"):void
 		output2("\n<b>* Butt, Size Rating:</b> " + formatFloat(pc.buttRating(), 3));
 		if(pc.buttRatingMod != 0) output2(" (" + StringUtil.printPlusMinus(formatFloat(pc.buttRatingMod, 3)) + ")");
 		if(pc.buttRatingMod != 0 && pc.siliconeRating("butt") != 0) output2("\n<b>* Butt, Silicone Size Rating:</b> " + formatFloat(pc.siliconeRating("butt"), 3));
-		output2("\n<b>* Butt, Weight:</b> " + prettifyWeight(pc.bodyPartWeight("butt")));
+		output2("\n<b>* Butt, Weight:</b> " + UnitSystem.displayWeightShort(pc.bodyPartWeight("butt")));
 		if(pc.weightQ("butt") > 0) output2(" (" + pc.weightQ("butt") + " %)");
 		if(pc.buttTone() != pc.tone) output2("\n<b>* Butt, Tone:</b> " + pc.toneMin() + "/" + pc.buttTone() + "/" + pc.toneMax());
 		output2("\n<b>* Anus:</b> 1,");
@@ -729,11 +729,11 @@ public function statisticsScreen(showID:String = "All"):void
 		output2("\n<b>* Anus, Virginity:</b>");
 		if(pc.analVirgin) output2(" Virgin");
 		else output2(" Taken");
-		if(pc.ass.bonusCapacity == 0) output2("\n<b>* Anus, Capacity:</b> " + prettifyVolume(pc.analCapacity()));
+		if(pc.ass.bonusCapacity == 0) output2("\n<b>* Anus, Capacity:</b> " + UnitSystem.displayVolumeShort(pc.analCapacity()));
 		else
 		{
-			output2("\n<b>* Anus, Capacity, Bonus:</b> " + prettifyVolume(pc.ass.bonusCapacity));
-			output2("\n<b>* Anus, Capacity, Effective:</b> " + prettifyVolume(pc.analCapacity()));
+			output2("\n<b>* Anus, Capacity, Bonus:</b> " + UnitSystem.displayVolumeShort(pc.ass.bonusCapacity));
+			output2("\n<b>* Anus, Capacity, Effective:</b> " + UnitSystem.displayVolumeShort(pc.analCapacity()));
 		}
 		output2("\n<b>* Anus, Looseness Level:</b> " + formatFloat(pc.ass.looseness(), 3));
 		output2("\n<b>* Anus, Wetness Level:</b> " + formatFloat(pc.ass.wetness(), 3));
@@ -5150,7 +5150,7 @@ public function displayEncounterLog(showID:String = "All"):void
 						if(flags["SAEN_X_SERA_THREESOME"] > 0) output2(" (with threesome discount)");
 					}
 				}
-				if(StatTracking.getStat("milkers/sera milker") > 0) output2("\n<b>* Breast Milker, Fluid Milked:</b> " + mLs(Math.round(StatTracking.getStat("milkers/sera milker"))));
+				if(StatTracking.getStat("milkers/sera milker") > 0) output2("\n<b>* Breast Milker, Fluid Milked:</b> " + UnitSystem.displayLitersShort(Math.round(StatTracking.getStat("milkers/sera milker"))));
 				if(flags["MET_CHRYSALIS_DRONE"] != undefined) output2("\n<b>* Mods4U Drone:</b> Met it");
 				output2("\n<b>* Sera:</b> Met her");
 				if(flags["SERA_NO_SEX"] == 1) output2(", Pissed off at you indefinitely");
@@ -5173,7 +5173,7 @@ public function displayEncounterLog(showID:String = "All"):void
 					else output2(", Vented her frustrations");
 				}
 				output2("\n<b>* Sera, Skin Tone:</b> " + StringUtil.toDisplayCase(chars["SERA"].skinTone));
-				if(flags["SERA_INCH_STEAL"] != undefined) output2("\n<b>* Sera, Tail Length:</b> " + prettifyLength(36 + seraInchGain()));
+				if(flags["SERA_INCH_STEAL"] != undefined) output2("\n<b>* Sera, Tail Length:</b> " + UnitSystem.displayPreciseLengthShort2(36 + seraInchGain()));
 				if(fuckedSeraBefore())
 				{
 					if(chars["SERA"].hasCock())
@@ -5512,7 +5512,7 @@ public function displayEncounterLog(showID:String = "All"):void
 				if(flags["USED_NURSERY_COMPUTER"] != undefined) output2("\n<b>* Computer:</b> Used");
 				if(StatTracking.getStat("nursery/milk milked") > 0)
 				{
-					output2("\n<b>* Milking Room, Fluid Milked:</b> " + mLs(Math.round(StatTracking.getStat("nursery/milk milked"))));
+					output2("\n<b>* Milking Room, Fluid Milked:</b> " + UnitSystem.displayLitersShort(Math.round(StatTracking.getStat("nursery/milk milked"))));
 				}
 				if(flags["BRIGET_MET"] != undefined)
 				{
@@ -5740,12 +5740,12 @@ public function displayEncounterLog(showID:String = "All"):void
 				if(StatTracking.getStat("milkers/breast milker uses") > 0)
 				{
 					output2("\n<b>* Milker, Breast, Times Used:</b> " + StatTracking.getStat("milkers/breast milker uses"));
-					output2("\n<b>* Milker, Breast, Fluid Milked:</b> " + mLs(Math.round(StatTracking.getStat("milkers/milk milked"))));
+					output2("\n<b>* Milker, Breast, Fluid Milked:</b> " + UnitSystem.displayLitersShort(Math.round(StatTracking.getStat("milkers/milk milked"))));
 				}
 				if(StatTracking.getStat("milkers/prostate milker uses") > 0)
 				{
 					output2("\n<b>* Milker, Prostate, Times Used:</b> " + StatTracking.getStat("milkers/prostate milker uses"));
-					output2("\n<b>* Milker, Prostate, Cum Milked:</b> " + mLs(Math.round(StatTracking.getStat("milkers/cum milked"))));
+					output2("\n<b>* Milker, Prostate, Cum Milked:</b> " + UnitSystem.displayLitersShort(Math.round(StatTracking.getStat("milkers/cum milked"))));
 					if(flags["NT_TAILCOCK_MILKINGS"] != undefined) output2("\n<b>* Milker, Prostate, Times Used with Parasitic Tail-Cock:</b> " + flags["NT_TAILCOCK_MILKINGS"]);
 				}
 				// Brynn
@@ -5776,7 +5776,7 @@ public function displayEncounterLog(showID:String = "All"):void
 						if(flags["CARRIE_BLOWJOBBED"] != 1) output2(" " + flags["CARRIE_BLOWJOBBED"] + " times");
 					}
 					if(flags["CARRIE_SMALLCOCK_SUX"] != undefined) output2(", Sucked your small cock");
-					if(StatTracking.getStat("milkers/cum jarred") > 0) output2("\n<b>* Carrie, Cum Jarred:</b> " + mLs(Math.round(StatTracking.getStat("milkers/cum jarred"))));
+					if(StatTracking.getStat("milkers/cum jarred") > 0) output2("\n<b>* Carrie, Cum Jarred:</b> " + UnitSystem.displayLitersShort(Math.round(StatTracking.getStat("milkers/cum jarred"))));
 					if(flags["CAMERON_MILKED"] != undefined) output2("\n<b>* Carrie, Times fucked her and Cameron:</b> " + flags["CAMERON_MILKED"]);
 					if(flags["CORA_SUCKED"] != undefined)
 					{
@@ -5878,7 +5878,7 @@ public function displayEncounterLog(showID:String = "All"):void
 					if(flags["FUCKED_BY_HALEY"] != undefined) output2(", Fucked by her");
 					if(flags["USED_MILKER"] != undefined) output2("\n<b>* Haley, Times Used Taur-Milker:</b> " + flags["USED_MILKER"]);
 					if(StatTracking.getStat("contests/haley milker losses") + StatTracking.getStat("contests/haley milker wins") > 0) output2("\n<b>* Haley, Milking Competition, Win/Loss Ratio:</b> " + StatTracking.getStat("contests/haley milker wins") + "/" + StatTracking.getStat("contests/haley milker losses") + ", of " + (StatTracking.getStat("contests/haley milker losses") + StatTracking.getStat("contests/haley milker wins")) + " games");
-					if(StatTracking.getStat("haley milker/cum milked") > 0) output2("\n<b>* Haley, Milking Competition, Your Cum Milked:</b> " + mLs(Math.round(StatTracking.getStat("haley milker/cum milked"))));
+					if(StatTracking.getStat("haley milker/cum milked") > 0) output2("\n<b>* Haley, Milking Competition, Your Cum Milked:</b> " + UnitSystem.displayLitersShort(Math.round(StatTracking.getStat("haley milker/cum milked"))));
 					if(pc.hasStatusEffect("Won Haley's Credits")) output2("\n<b>* Haley, Milking Competition, Time Until Next Prize:</b> " + prettifyMinutes(pc.getStatusMinutes("Won Haley's Credits")));
 				}
 				// Millie milks!
@@ -7297,7 +7297,7 @@ public function displayEncounterLog(showID:String = "All"):void
 				if(pc.keyItemv1("Gildenmere Pass") >= 1) output2(" Allowed access");
 				else output2(" <i>Ask Lyralla for an entrance pass.</i>");
 				if(flags["THOLLUM_TOURED"] != undefined) output2(", Taken tour");
-				if(flags["MUSHROOM_TRACKER"] != undefined && flags["MUSHROOM_TRACKER"] > 0) output2("\n<b>* Mushroom Garden, Fluids Collected:</b> " + mLs(flags["MUSHROOM_TRACKER"]));
+				if(flags["MUSHROOM_TRACKER"] != undefined && flags["MUSHROOM_TRACKER"] > 0) output2("\n<b>* Mushroom Garden, Fluids Collected:</b> " + UnitSystem.displayLitersShort(flags["MUSHROOM_TRACKER"]));
 				if(flags["MUSH_SEEN"] != undefined) output2("\n<b>* Mushroom Garden, Growth Level:</b> " + flags["MUSH_SEEN"]);
 				// Yarasta
 				if(flags["MET_YARASTA"] != undefined) output2("\n<b>* Yarasta:</b> Met her");
@@ -8903,7 +8903,7 @@ public function displayEncounterLog(showID:String = "All"):void
 			{
 				output2("\n<b><u>Spunk Bunker</u></b>");
 				if(flags["KIRO_KALLY_TEAM_MILKED"] != undefined) output2("\n<b>* Services, Times Cock-Milked with Kiro and Kally:</b> " + flags["KIRO_KALLY_TEAM_MILKED"]);
-				if(StatTracking.getStat("spunk bunker/cum milked") > 0) output2("\n<b>* Services, Cock-Milker, Cum Milked:</b> " + mLs(Math.round(StatTracking.getStat("spunk bunker/cum milked"))));
+				if(StatTracking.getStat("spunk bunker/cum milked") > 0) output2("\n<b>* Services, Cock-Milker, Cum Milked:</b> " + UnitSystem.displayLitersShort(Math.round(StatTracking.getStat("spunk bunker/cum milked"))));
 				if(flags["VIXETTE_MOUTHGASMED"] != undefined) output2("\n<b>* Vixette, Times She Sucked Your Dick:</b> " + flags["VIXETTE_MOUTHGASMED"]);
 				variousCount++;
 			}
@@ -8970,7 +8970,7 @@ public function displayEncounterLog(showID:String = "All"):void
 					output2("\n<b>* Services, Sperm Donation Bay, Times Donated:</b> " + flags["BREEDWELL_TIMES_DONATED"]);
 					if(flags["BREEDWELL_DONATION_LOCKED"] != undefined) output2(", Locked");
 					else if(flags["BREEDWELL_DONATION_USED"] != undefined && (flags["BREEDWELL_DONATION_USED"] < days)) output2(", Last used " + ((days - flags["BREEDWELL_DONATION_USED"] == 1) ? "yesterday" : ((days - flags["BREEDWELL_DONATION_USED"]) + " days ago")));
-					output2("\n<b>* Services, Sperm Donation Bay, Cum Milked:</b> " + mLs(Math.round(StatTracking.getStat("breedwell/cum milked"))));
+					output2("\n<b>* Services, Sperm Donation Bay, Cum Milked:</b> " + UnitSystem.displayLitersShort(Math.round(StatTracking.getStat("breedwell/cum milked"))));
 				}
 				variousCount++;
 			}
@@ -9282,7 +9282,7 @@ public function displayEncounterLog(showID:String = "All"):void
 				if(flags["KIRO_DRINKING_CONTEST_RESULTS"] < 0) output2(" Lost against her");
 				if(StatTracking.getStat("contests/kiro drinkoff losses") + StatTracking.getStat("contests/kiro drinkoff wins") > 0) output2("\n<b>* Kiro, Drinking Contest, Win/Loss Ratio:</b> " + StatTracking.getStat("contests/kiro drinkoff wins") + "/" + StatTracking.getStat("contests/kiro drinkoff losses") + ", of " + (StatTracking.getStat("contests/kiro drinkoff losses") + StatTracking.getStat("contests/kiro drinkoff wins")) + " games");
 			}
-			output2("\n<b>* Kiro, Testicle Size:</b> " + prettifyLength(chars["KIRO"].ballDiameter()) + " across, " + prettifyLength(chars["KIRO"].ballSize()) + " around, each");
+			output2("\n<b>* Kiro, Testicle Size:</b> " + UnitSystem.displayPreciseLengthShort2(chars["KIRO"].ballDiameter()) + " across, " + UnitSystem.displayPreciseLengthShort2(chars["KIRO"].ballSize()) + " around, each");
 			if(kiroSexed())
 			{
 				output2("\n<b>* Kiro, Sexual Organs:</b> " + listCharGenitals("KIRO"));
@@ -9708,8 +9708,8 @@ public function displayEncounterLog(showID:String = "All"):void
 		if(StatTracking.getStat("joyco/milk milked") + StatTracking.getStat("joyco/cum milked") > 0)
 		{
 			output2("\n<b><u>Contributions</u></b>");
-			if(StatTracking.getStat("joyco/milk milked") > 0) output2("\n<b>* JoyCo, Milk Fluid Milked:</b> " + mLs(Math.round(StatTracking.getStat("joyco/milk milked"))));
-			if(StatTracking.getStat("joyco/cum milked") > 0) output2("\n<b>* JoyCo, Cum Fluid Milked:</b> " + mLs(Math.round(StatTracking.getStat("joyco/cum milked"))));
+			if(StatTracking.getStat("joyco/milk milked") > 0) output2("\n<b>* JoyCo, Milk Fluid Milked:</b> " + UnitSystem.displayLitersShort(Math.round(StatTracking.getStat("joyco/milk milked"))));
+			if(StatTracking.getStat("joyco/cum milked") > 0) output2("\n<b>* JoyCo, Cum Fluid Milked:</b> " + UnitSystem.displayLitersShort(Math.round(StatTracking.getStat("joyco/cum milked"))));
 		}
 		// Sexploration: Porny Smuts
 		if(flags["LETS_FAP_ARCHIVES"] != undefined || flags["STEPH_WATCHED"] != undefined)


### PR DESCRIPTION
Allow to change the system of units displayed in the interface with the toggle of an option (for some parts of the game).

A new option to change between the imperial and International system has been added. Its default state is for the use of the imperial system (_inches, feet, pounds, ..._) and once toggled the values displayed to the user are in the International System (_centimeters, meters, grams, kilograms, liter, ..._).

A new class is in charge of displaying values in the correct system of units [`classes/Units/UnitSystem.as`]. 

As a first step towards complete adaptation, a few scripts have been change to use the automatic conversion of units :
- the character creation scene [`includes/creation.as`]
- characters appearance [`includes/creation.as`]
- personal statistics [`includes/gameStats.as`]

Some sort of conversion was already in place for the personal statistics, but it has been supplanted by the new system.

The next step would be to adapt the rest of the project to use the unit system manager.