### PR TITLE
Check for storage permissions for load/save to file on Android

### DIFF
--- a/asconfig.json
+++ b/asconfig.json
@@ -1,0 +1,80 @@
+{
+	"compilerOptions": {
+		"source-path": [
+			"."
+		],
+		"output": "bin/TITS_AIR.swf",
+		"default-frame-rate": 24,
+		"default-background-color": "#3D5174",
+		"default-size": {
+			"width": 1200,
+			"height": 800
+		},
+		"accessible": false,
+		"swf-version": 35,
+		"benchmark": false,
+		"optimize": true,
+		"omit-trace-statements": false,
+		"show-unused-type-selector-warnings": true,
+		"strict": true,
+		"use-network": false,
+		"use-resource-bundle-metadata": true,
+		"warnings": true,
+		"verbose-stacktraces": false,
+		"static-link-runtime-shared-libraries": true,
+		"define": [
+			{
+				"name": "CONFIG::IMAGEPACK",
+				"value": false
+			},
+			{
+				"name": "CONFIG::AIR",
+				"value": true
+			},
+			{
+				"name": "CONFIG::FLASH",
+				"value": false
+			},
+			{
+				"name": "CONFIG::CHARGEN",
+				"value": false
+			},
+			{
+				"name": "CONFIG::debug",
+				"value": false
+			},
+			{
+				"name": "CONFIG::release",
+				"value": true
+			}
+		],
+		"library-path": [
+			"style_uiscroll.swc",
+			"/home/typhlosiondicks/Drive/flash.swc"
+		]
+	},
+	"files": [
+		"classes/TiTS.as"
+	],
+	"config": "airmobile",
+	"airOptions": {
+		"android": {
+			"target": "apk-captive-runtime",
+			"arch": "x86",
+			"platformsdk": "/home/typhlosiondicks/Android/Sdk",
+			"signingOptions": {
+				"keystore": "cert/AirTemplateProj.p12",
+				"storetype": "pkcs12"
+			},
+			"connect": false
+		},
+		"files": [
+			{
+				"file": "icons/android/icons",
+				"path": "icons"
+			}
+		]
+	},
+	"application": "application.xml",
+	"additionalOptions": "-managers flash.fonts.AFEFontManager -keep-as3-metadata+=Serialize"
+}

--- a/classes/DataManager/DataManager.as
+++ b/classes/DataManager/DataManager.as
@@ -46,7 +46,9 @@
 			import flash.filesystem.File;
 			import flash.filesystem.FileMode;
 			import flash.filesystem.FileStream;
+			import flash.permissions.PermissionStatus;
 			import flash.events.ProgressEvent;
+			import flash.events.PermissionEvent;
 		}
 	
 		// Define the current version of save games.
@@ -63,11 +65,15 @@
 			private var stickyFileRef:File;
 			private var stickyFileStreamRef:FileStream;
 			private var saveDir:String = "data/com.taintedspace.www";
+
+			private var _saveToFileEnabled:Boolean = IsDesktopAir || (File.permissionStatus == PermissionStatus.GRANTED);
 		}
 		
 		CONFIG::FLASH
 		{
 			private var stickyFileRef:FileReference;
+
+			private var _saveToFileEnabled:Boolean = true;
 		}
 		
 		public function DataManager() 
@@ -224,17 +230,42 @@
 			
 			kGAMECLASS.userInterface.mainButtonsOnly();
 			kGAMECLASS.userInterface.clearGhostMenu();
+
+			// "Advanced" file handling methods ultimately require us to be using the AIR api
+			// Moved this a bit further up so that Android fs perms can be checked at the same time
+			CONFIG::AIR
+			{
+				kGAMECLASS.addGhostButton(7, "Delete File", this.deleteFileMenu, undefined, "Delete File", "Delete a save file.");
+				
+				// Hide the "import saves" and "save sets" option for operating systems we don't support
+				if (IsDesktopAir)
+				{
+					kGAMECLASS.addGhostButton(10, "Import Saves", this.importSavesMenu, undefined, "Import Saves", "Attempt to import saves from other game sources.");
+					if (hasAnyImportedSaves()) kGAMECLASS.addGhostButton(11, "Save Set", this.saveSetMenu, undefined, "Save Set", "Switch between available imported save slot sets.");
+				}
+
+				// If this isn't 'Desktop', this is probably Android, so check to make sure the filesystem can be accessed
+				else if (!this._saveToFileEnabled)
+				{
+					kGAMECLASS.addGhostButton(11, "Allow Storage", this.requestMobileFilesystemPerms, undefined, "Allow Storage", "Ask for permission to save and load from local file storage.");
+					kGAMECLASS.addDisabledGhostButton(5, "Load File", "Load from File", "Loading from files requires the permission to access storage.");
+					kGAMECLASS.addDisabledGhostButton(6, "Save File", "Save to File", "Saving to files requires the permission to access storage.");
+				}
+			}
 			
+			if (this._saveToFileEnabled) {
+				kGAMECLASS.addGhostButton(5, "Load File", this.loadFromFile, undefined, "Load from File", "Load game data from a specific file.");
+				if (kGAMECLASS.canSaveAtCurrentLocation) kGAMECLASS.addGhostButton(6, "Save File", this.saveToFile, undefined, "Save to File", "Save game data to a specific file.");
+				else kGAMECLASS.addDisabledGhostButton(6, "Save File", "Save to File", "You can’t save in your current location.");
+			}
+
 			kGAMECLASS.addGhostButton(0, "Load", this.loadGameMenu, undefined, "Load Game", "Load game data.");
 			if (kGAMECLASS.canSaveAtCurrentLocation) kGAMECLASS.addGhostButton(1, "Save", this.saveGameMenu, undefined, "Save Game", "Save game data.");
 			else kGAMECLASS.addDisabledGhostButton(1, "Save", "Save Game", "You can’t save in your current location.");
 			kGAMECLASS.addGhostButton(3, "Delete", this.deleteSaveMenu, undefined, "Delete Save", "Delete a save game slot."); // Added for parity with AIR, because it kinda has to be there...
 			
-			kGAMECLASS.addGhostButton(5, "Load File", this.loadFromFile, undefined, "Load from File", "Load game data from a specific file.");
-			if (kGAMECLASS.canSaveAtCurrentLocation) kGAMECLASS.addGhostButton(6, "Save File", this.saveToFile, undefined, "Save to File", "Save game data to a specific file.");
-			else kGAMECLASS.addDisabledGhostButton(6, "Save File", "Save to File", "You can’t save in your current location.");
-			
 			// "Advanced" file handling methods ultimately require us to be using the AIR api
+			/*
 			CONFIG::AIR
 			{
 				kGAMECLASS.addGhostButton(7, "Delete File", this.deleteFileMenu, undefined, "Delete File", "Delete a save file.");
@@ -246,6 +277,7 @@
 					if (hasAnyImportedSaves()) kGAMECLASS.addGhostButton(11, "Save Set", this.saveSetMenu, undefined, "Save Set", "Switch between available imported save slot sets.");
 				}
 			}
+			*/
 			
 			kGAMECLASS.addGhostButton(14, "Back", dataRouter);
 		}
@@ -1117,6 +1149,23 @@
 		{
 			private var baDataBlob:ByteArray;
 			
+			private function requestMobileFilesystemPerms():void
+			{
+				kGAMECLASS.clearOutput2();
+				kGAMECLASS.userInterface.clearGhostMenu();
+				kGAMECLASS.output2("Requesting filesystem access... ");
+				stickyFileRef = File.documentsDirectory;
+				stickyFileRef.addEventListener(PermissionEvent.PERMISSION_STATUS, permissionEventHandler);
+				stickyFileRef.requestPermission();
+			}
+
+			private function permissionEventHandler(evnt:PermissionEvent):void
+			{
+				stickyFileRef.removeEventListener(PermissionEvent.PERMISSION_STATUS, permissionEventHandler);
+				this._saveToFileEnabled = (evnt.status == PermissionStatus.GRANTED);
+				this.showDataMenu();
+			}
+
 			private function saveToFile():void
 			{
 				if (kGAMECLASS.userInterface.systemText != "BY FENOXO") kGAMECLASS.showName("SAVE\nFILE");

--- a/classes/Resources/Busts/ShouBusts.as
+++ b/classes/Resources/Busts/ShouBusts.as
@@ -749,7 +749,7 @@
 		[Embed(source = "../../../assets/images/npcs/shou_puppy/waralpha_nude.png", mimeType = "image/png")]
 		public var Bust_WAR_ALPHA_NUDE:Class;
 
-		[Embed(source = "../../../assets/images/npcs/shou_puppy/warlion.png", mimeType = "image/png")]
+		[Embed(source = "../../../assets/images/npcs/shou_puppy/warLion.png", mimeType = "image/png")]
 		public var Bust_WAR_LION:Class;
 		[Embed(source = "../../../assets/images/npcs/shou_puppy/warlion_nude.png", mimeType = "image/png")]
 		public var Bust_WAR_LION_NUDE:Class;

--- a/classes/TiTS.as
+++ b/classes/TiTS.as
@@ -489,7 +489,7 @@
 		include "../includes/zhengShiStation/cherrysAppt.as";
 		include "../includes/zhengShiStation/coronaFlamer.as";
 		include "../includes/zhengShiStation/dane.as";
-		include "../includes/zhengShiStation/forgehound.as";
+		include "../includes/zhengShiStation/forgeHound.as";
 		include "../includes/zhengShiStation/ldc_and_shock_hopper.as";
 		include "../includes/zhengShiStation/lorelei.as";
 		include "../includes/zhengShiStation/maike.as";


### PR DESCRIPTION
I did this some days ago. It honestly seemed like an easy fix, and I thought it might not have been worth a PR, but screw it.

The first commit simply exists because I don't use Windows that often, so using FlashDevelop isn't an option for me (I can use Flash CS6, but its 32-bit-ness makes me unable to build TiTS with it). The second commit changes `swf-version` to 35 (AIR 24) so that dynamic permissions can be used. It also changes the data menu so that

1. "Load from File" and "Save to File" are 'greyed out' unless the app actually has the necessary permisison to use those functions, and
2. in the case of the app not having said permission, adds a new button to the menu that can request it.

I don't actually own any real Android devices, but if it works on ChromeOS then I imagine there would be no difference. At the very least, it does look like it fixes the problem for ChromeOS specifically, as well as manually enabling the storage permission in the settings for the app.

As a bit of a side-note, I was wondering to myself if it's possible to detect that the game is running on a ChromeOS version of Android and setting the directory that saving/loading from file uses to `/Downloads` instead of `/data` in that case, since it is symlinked to ChromeOS' Downloads folder and is more easily accessible, but I don't think it's possible without making an ANE, which is probably too much effort for something so small (plus I don't know the process of building an ANE that targets Android)