### PR TITLE
Bubble Buddy Bukkake Blaster

### DIFF
--- a/classes/Engine/Combat/hasAmmo.as
+++ b/classes/Engine/Combat/hasAmmo.as
@@ -1,0 +1,29 @@
+package classes.Engine.Combat 
+{
+	import classes.Characters.PlayerCharacter;
+	import classes.Creature;
+	import classes.Engine.Utility.rand;
+	import classes.GLOBAL;
+	import classes.Engine.Interfaces.output;
+	import classes.kGAMECLASS;
+
+	//Router function to find the appropriate ammo manager
+	public function hasAmmo(attacker:Creature, expendAmmo:Boolean):Boolean
+	{
+		//Putting this here in case of future npc ammo user
+		if (!attacker is PlayerCharacter)
+		{
+			return false;
+		}
+		
+		switch (true)
+		{
+			case attacker.rangedWeapon.longName == "Bubble Buddy Bukkake Blaster":
+				return kGAMECLASS.bukkakeBlasterAmmoManager(attacker,  expendAmmo);
+				break;
+				
+			default:
+				return false;
+		}
+	}
+}

--- a/classes/GLOBAL.as
+++ b/classes/GLOBAL.as
@@ -1267,6 +1267,7 @@
 		public static const ITEM_FLAG_ALCOHOLIC:int						= 51; //For hooch
 		public static const ITEM_FLAG_MEDICINE:int						= 52; //For things that can cure disease, NOT WOUNDS
 		public static const ITEM_FLAG_PRESSURIZED:int					= 53; //maintains internal pressure to protect vs high and low pressure environments
+		public static const ITEM_FLAG_REQUIRES_AMMO:int					= 54; //For items that require an external ammo source
 		
 		public static const ITEM_FLAG_NAMES:Array = [
 			"Bow Weapon",
@@ -1323,6 +1324,7 @@
 			"Alcoholic",
 			"Medicine",
 			"Pressurized",
+			"Requires Ammo",
 		];
 		
 		/**

--- a/classes/GameData/CombatAttacks.as
+++ b/classes/GameData/CombatAttacks.as
@@ -593,6 +593,17 @@ package classes.GameData
 		 */
 		public static function SingleRangedAttackImpl(attacker:Creature, target:Creature, asFlurry:Boolean = false, special:String = "ranged"):Boolean
 		{
+			//Can't fire without ammo
+			if (attacker.rangedWeapon.hasFlag(GLOBAL.ITEM_FLAG_REQUIRES_AMMO))
+			{
+				if (!hasAmmo(attacker, true)) 
+				{
+					if (attacker is PlayerCharacter) output("Your " + attacker.rangedWeapon.longName + " is out of ammo!");
+					else output(StringUtil.capitalize(attacker.getCombatName(), false) + " fiddle" + (attacker.isPlural ? "" : "s") + " fruitlessly with " + attacker.getCombatPronoun("hisher") + " empty weapon.");
+					return false;
+				}
+			}
+			
 			if(target is Kane && target.hasStatusEffect("KANE RANGED PREP") && !target.hasStatusEffect("KANE_AI_SKIP") && !target.isImmobilized())
 			{
 				kGAMECLASS.kaneRangedInterrupt();
@@ -963,6 +974,17 @@ package classes.GameData
 				if (attacker is PlayerCharacter) output("Your " + attacker.rangedWeapon.longName + " is currently disabled and unable to be used!");
 				else output(StringUtil.capitalize(attacker.getCombatName(), false) + " fiddle" + (attacker.isPlural ? "" : "s") + " fruitlessly with " + attacker.getCombatPronoun("hisher") + " disabled weapon.");
 				return;
+			}
+			
+			//Ammo check
+			if (attacker.rangedWeapon.hasFlag(GLOBAL.ITEM_FLAG_REQUIRES_AMMO))
+			{
+				if (!hasAmmo(attacker, false)) 
+				{
+					if (attacker is PlayerCharacter) output("Your " + attacker.rangedWeapon.longName + " is out of ammo!");
+					else output(StringUtil.capitalize(attacker.getCombatName(), false) + " fiddle" + (attacker.isPlural ? "" : "s") + " fruitlessly with " + attacker.getCombatPronoun("hisher") + " empty weapon.");
+					return;
+				}
 			}
 			
 			var numShots:int = 1;

--- a/classes/GameData/GroundCombatContainer.as
+++ b/classes/GameData/GroundCombatContainer.as
@@ -3,6 +3,7 @@ package classes.GameData
 	import classes.Characters.PlayerCharacter;
 	import classes.Creature;
 	import classes.Characters.Vahn;
+	import classes.Items.Guns.BubbleBuddyBukkakeBlaster;
 	import classes.ShittyShip;
 	import classes.Engine.Combat.DamageTypes.DamageResult;
 	import classes.Items.Accessories.SiegwulfeItem; 
@@ -41,6 +42,8 @@ package classes.GameData
 	import classes.Engine.Combat.DamageTypes.*;
 	import classes.UIComponents.UIStyleSettings;
 	import classes.Engine.Utility.IncrementFlag;
+	import classes.Items.Toys.Bubbles.*;
+	
 	
 	public class GroundCombatContainer extends CombatContainer 
 	{		
@@ -4812,7 +4815,8 @@ package classes.GameData
 				}
 			}
 			if(pc.hasKeyItem("RK Lah - Captured")) kGAMECLASS.lahAddendumToCombat();
-
+			
+			if (pc.meleeWeapon.hasFlag(GLOBAL.ITEM_FLAG_REQUIRES_AMMO) || pc.rangedWeapon.hasFlag(GLOBAL.ITEM_FLAG_REQUIRES_AMMO)) displayAmmoStatus(); 
 		}
 		
 		private function displayHostileStatus(target:Creature):void
@@ -5699,6 +5703,43 @@ package classes.GameData
 			}
 			
 			//output("\n\n");
+		}
+		
+		private function displayAmmoStatus():void
+		{
+			var hasReloads:Boolean = false;
+			//BBBB
+			if (pc.rangedWeapon is BubbleBuddyBukkakeBlaster)
+			{
+				output("\n\nBubble Buddy Bukkake Blaster shots remaining: " + flags["BBBB_CURRENT_AMMO"] + "/20\n");
+				output("<b>Reloads:</b>\n");
+				
+				if (pc.numberOfItemByClass(SmallCumBubble) > 0)
+				{
+					output("Small Cum Bubbles (2 shots): " + pc.numberOfItemByClass(SmallCumBubble) + "\n");
+					hasReloads = true;
+				}
+				
+				if (pc.numberOfItemByClass(MediumCumBubble) > 0)
+				{
+					output("Medium Cum Bubbles (5 shots): " + pc.numberOfItemByClass(MediumCumBubble) + "\n");
+					hasReloads = true;
+				}
+				
+				if (pc.numberOfItemByClass(LargeCumBubble) > 0)
+				{
+					output("Large Cum Bubbles (10 shots): " + pc.numberOfItemByClass(LargeCumBubble) + "\n");
+					hasReloads = true;
+				}
+				
+				if (pc.numberOfItemByClass(HugeCumBubble) > 0)
+				{
+					output("Huge Cum Bubbles (20 shots): " + pc.numberOfItemByClass(HugeCumBubble) + "\n");
+					hasReloads = true;
+				}
+				
+				if (!hasReloads) output("No reloads left!");
+			}
 		}
 	}
 }

--- a/classes/Items/Guns/BubbleBuddyBukkakeBlaster.as
+++ b/classes/Items/Guns/BubbleBuddyBukkakeBlaster.as
@@ -1,0 +1,79 @@
+package classes.Items.Guns
+{
+	import classes.Engine.Interfaces.*;
+	import classes.ItemSlotClass;
+	import classes.GLOBAL;
+	import classes.GameData.TooltipManager;
+	import classes.Creature;
+	import classes.StringUtil;
+	import classes.Engine.Combat.DamageTypes.TypeCollection;
+	import classes.Engine.Combat.DamageTypes.DamageFlag;
+	import classes.Characters.PlayerCharacter;
+	import classes.kGAMECLASS;
+	import classes.Items.Toys.Bubbles.*;
+	import classes.Engine.Utility.*;
+	import classes.Engine.Interfaces.*;
+	import classes.Engine.Combat.*;
+	import classes.Engine.Combat.DamageTypes.*;
+	import classes.StringUtil;
+	
+	public class BubbleBuddyBukkakeBlaster extends ItemSlotClass
+	{
+		//BBBB variables
+		public var maxAmmo:int = 20
+		public var currentAmmo:int = 0
+		
+		public var itemInstance:ItemSlotClass;
+		
+		//constructor
+		public function BubbleBuddyBukkakeBlaster()
+		{
+			this._latestVersion = 1;
+
+			this.quantity = 1;
+			this.stackSize = 1;
+			this.type = GLOBAL.RANGED_WEAPON;
+			
+			//Used on inventory buttons
+			this.shortName = "B.B.B.B.";
+			
+			//Regular name
+			this.longName = "Bubble Buddy Bukkake Blaster"
+			
+			TooltipManager.addFullName(this.shortName, StringUtil.toTitleCase(this.longName));
+			
+			//Longass shit, not sure what used for yet.
+			this.description = "a cum-thrower";
+			 
+			//Displayed on tooltips during mouseovers
+			this.tooltip = "[altTooltip BubbleBuddyBukkakeBlaster]";
+			
+			this.attackVerb = "spray";
+			attackNoun = "stream of cum";
+			
+			TooltipManager.addTooltip(this.shortName, this.tooltip);
+			
+			//Information
+			this.basePrice = 25000;
+			this.attack = 0;
+			
+			baseDamage = new TypeCollection();
+			baseDamage.tease.damageValue = 6;
+			baseDamage.addFlag(DamageFlag.NO_CRIT);
+			addFlag(GLOBAL.ITEM_FLAG_BLIND_IGNORE);
+			addFlag(GLOBAL.ITEM_FLAG_REQUIRES_AMMO);
+			addFlag(GLOBAL.ITEM_FLAG_LUST_WEAPON);
+			addFlag(GLOBAL.ITEM_FLAG_EFFECT_FLURRYBONUS);
+			
+			this.defense = 0;
+			this.shieldDefense = 0;
+			this.shields = 0;
+			this.sexiness = 0;
+			this.critBonus = 0;
+			this.evasion = 0;
+			this.fortification = 0;
+
+			this.version = _latestVersion;
+		}
+	}
+}

--- a/includes/items.as
+++ b/includes/items.as
@@ -3,6 +3,7 @@ import classes.Characters.Lerris;
 import classes.Characters.PlayerCharacter;
 import classes.Characters.Vahn;
 import classes.Creature;
+import classes.Items.Guns.BubbleBuddyBukkakeBlaster;
 import classes.Items.Transformatives.GaloMax;
 import classes.Items.Transformatives.SumaCreamBlack;
 import classes.Items.Transformatives.SumaCreamWhite;
@@ -1040,6 +1041,7 @@ public function shopkeepLimitedStock(arg:ItemSlotClass):Boolean
 		case arg is MindwashVisor:
 		case arg is SiegwulfeItem:
 		case arg is TarkusJokeBook:
+		case arg is BubbleBuddyBukkakeBlaster:
 			return true;
 			break;
 		default:
@@ -1062,6 +1064,7 @@ public function shopkeepLimitedStockQuantity(arg:ItemSlotClass):int
 		case arg is MindwashVisor:
 		case arg is SiegwulfeItem:
 		case arg is TarkusJokeBook:
+		case arg is BubbleBuddyBukkakeBlaster:
 			return 1;
 			break;
 		default:
@@ -1298,6 +1301,11 @@ public function buyItemGo(arg:Array):void {
 	}
 	if(arg[0] is MindwashVisor)
 	{
+		shopkeep.inventory.splice(shopkeep.inventory.indexOf(arg[0]), 1);
+	}
+	if (arg[0] is BubbleBuddyBukkakeBlaster)
+	{
+		flags["BBBB_CURRENT_AMMO"] = 0;
 		shopkeep.inventory.splice(shopkeep.inventory.indexOf(arg[0]), 1);
 	}
 	output("\n\n");
@@ -1744,7 +1752,8 @@ public function dropItemGo(arg:ItemSlotClass):void {
 	// Special Events
 	if(arg is GooArmor) output("\n\n" + gooArmorInventoryBlurb(arg, "drop"));
 	if(arg is HorseCock) IncrementFlag("SYNTHSHEATH_LOST");
-	if(arg is DamagedVIChip && flags["NYM-FOE_REPAIR_QUEST"] == 2) flags["NYM-FOE_REPAIR_QUEST"] = -2;
+	if (arg is DamagedVIChip && flags["NYM-FOE_REPAIR_QUEST"] == 2) flags["NYM-FOE_REPAIR_QUEST"] = -2;
+	if (arg is BubbleBuddyBukkakeBlaster) flags["BBBB_CURRENT_AMMO"] = undefined;
 	
 	arg.quantity--;
 	if (arg.quantity <= 0 && pc.inventory.indexOf(arg) != -1)

--- a/includes/items.tooltips.as
+++ b/includes/items.tooltips.as
@@ -25,6 +25,10 @@ public function altTooltip(itemName:String = "none"):String
 			break;
 		
 		// Weapons
+		case "BubbleBuddyBukkakeBlaster":
+			if (kGAMECLASS.flags["BBBB_CURRENT_AMMO"] == undefined) tooltip += "Created one night on a drunken bet, the Bubble Buddy Bukkake Blaster is a modified flamethrower, designed to spray your targets with sweet jizz rather than fiery death. Simply load in a cum bubble from your Bubble Buddy, point, and shoot! Includes an integrated Bubble Buddy, easily detachable Bubble Buddy to keep the spunky shine on your cum!";
+			else tooltip += "Created one night on a drunken bet, the Bubble Buddy Bukkake Blaster is a modified flamethrower, designed to spray your targets with sweet jizz rather than fiery death. Simply load in a cum bubble from your Bubble Buddy, point, and shoot! Includes an integrated Bubble Buddy, easily detachable Bubble Buddy to keep the spunky shine on your cum!\n\n Current Ammo: " + (kGAMECLASS.flags["BBBB_CURRENT_AMMO"]) + "/20";
+			break;
 		case "HoldOutPistol":
 			tooltip += "A simple black-powder pistol. It is easy to conceal but does not pack a particularly strong punch";
 			if(pc.characterClass == GLOBAL.CLASS_SMUGGLER) tooltip += ", the perfect weapon for a smuggler";

--- a/includes/masturbation.as
+++ b/includes/masturbation.as
@@ -529,7 +529,7 @@ public function availableFaps(roundTwo:Boolean = false, checkOnly:Boolean = fals
 		fap.func = dildoMenu;
 		faps.push(fap);
 	}
-	if(checkToyDrawer(BubbleBuddy) && pc.hasCock())
+	if(pc.hasCock() && (checkToyDrawer(BubbleBuddy) || pc.hasItemByClass(BubbleBuddyBukkakeBlaster) || pc.rangedWeapon is BubbleBuddyBukkakeBlaster))
 	{
 		fap = new FapCommandContainer();
 		fap.text = "BubbleBuddy";

--- a/includes/masturbation/bubbleBuddy.as
+++ b/includes/masturbation/bubbleBuddy.as
@@ -1,4 +1,6 @@
-﻿import classes.Items.Toys.Bubbles.HugeCumBubble;
+﻿import classes.Characters.PlayerCharacter;
+import classes.Items.Guns.BubbleBuddyBukkakeBlaster;
+import classes.Items.Toys.Bubbles.HugeCumBubble;
 import classes.Items.Toys.Bubbles.LargeCumBubble;
 import classes.Items.Toys.Bubbles.MediumCumBubble;
 import classes.Items.Toys.Bubbles.SmallCumBubble;
@@ -201,7 +203,8 @@ public function outOfCombatBubbleBuddyUse(item:ItemSlotClass):Boolean
 	addButton(2,"Put Away",putItAway,item);
 	if(pc.hasPerk("Dumb4Cum")) addButton(3,"Drink It",drinkSomeBubbleBud,item,"Drink It","Gosh, cum is tasty. Maybe you could like, drink some?");
 	else if(pc.hasPerk("'Nuki Nuts") && pc.hasCock() && pc.balls > 0) addButton(3,"Drink It",drinkSomeBubbleBud,item,"Drink It","Your ‘nuki nuts could use a little booster. Bottoms up!");
-	else addDisabledButton(3,"Drink It","Drink It","You have no reason to start drinking cum.");
+	else addDisabledButton(3, "Drink It", "Drink It", "You have no reason to start drinking cum.");
+	if ((pc.hasItemByClass(BubbleBuddyBukkakeBlaster) || pc.rangedWeapon is BubbleBuddyBukkakeBlaster) && flags["BBBB_CURRENT_AMMO"] < 20) addButton(4, "Refill B.B.B.B.", refillBBBB, item);
 	return true;
 }
 //[Ditch It]
@@ -1505,4 +1508,98 @@ public function bubbleBuddyVaandeEpilogue():void
 	for(var x:int = 0; x < 15; x++) { pc.orgasm(); }
 	clearMenu();
 	addButton(0,"Next",mainGameMenu);
+}
+
+public function bukkakeBlasterAmmoManager(attacker:Creature, expendAmmo:Boolean):Boolean
+{
+	//Put here just in case an npc ever gets one, but too lazy to do more than that
+	if (!attacker is PlayerCharacter)
+	{
+		return false;
+	}
+	
+	else
+	{
+		if (flags["BBBB_CURRENT_AMMO"] > 0)
+		{
+			if (expendAmmo) flags["BBBB_CURRENT_AMMO"] -= 1;
+			return true;
+		}
+		
+		//Reload actions: refill - 1 for the shot being used
+		//2 shots for a small
+		else if (flags["BBBB_CURRENT_AMMO"] == 0 && attacker.hasItemByClass(SmallCumBubble))
+		{
+			if (!expendAmmo) return true;
+			output("You load a small cum bubble into your Bubble Buddy Bukkake Blaster.\n");
+			attacker.destroyItemByClass(SmallCumBubble, 1);
+			flags["BBBB_CURRENT_AMMO"] += 1;
+			return true
+		}
+		
+		//5 for a medium
+		else if (flags["BBBB_CURRENT_AMMO"] == 0 && attacker.hasItemByClass(MediumCumBubble))
+		{
+			if (!expendAmmo) return true;
+			output("You load a medium cum bubble into your Bubble Buddy Bukkake Blaster.\n");
+			attacker.destroyItemByClass(MediumCumBubble, 1);
+			flags["BBBB_CURRENT_AMMO"] += 4;
+			return true
+		}
+		
+		//10 for a large
+		else if (flags["BBBB_CURRENT_AMMO"] == 0 && attacker.hasItemByClass(LargeCumBubble))
+		{
+			if (!expendAmmo) return true;
+			output("You load a large cum bubble into your Bubble Buddy Bukkake Blaster.\n");
+			attacker.destroyItemByClass(LargeCumBubble, 1);
+			flags["BBBB_CURRENT_AMMO"] += 9;
+			return true
+		}
+		
+		//20 for a huge
+		else if (flags["BBBB_CURRENT_AMMO"] == 0 && attacker.hasItemByClass(HugeCumBubble))
+		{
+			if (!expendAmmo) return true;
+			output("You load a huge cum bubble into your Bubble Buddy Bukkake Blaster.\n");
+			attacker.destroyItemByClass(HugeCumBubble, 1);
+			flags["BBBB_CURRENT_AMMO"] += 19;
+			return true
+		}
+		
+		else return false;
+	}
+}
+
+public function refillBBBB(item:ItemSlotClass):void
+{
+	clearMenu();
+	useItemFunction();
+	clearOutput();
+	
+	output("You load the " + item.longName + " into the Bubble Buddy Bukkake Blaster.");
+	itemConsume(item);
+	
+	switch (true)
+	{
+		case item is SmallCumBubble:
+			flags["BBBB_CURRENT_AMMO"] += 2;
+			if (flags["BBBB_CURRENT_AMMO"] > 20) flags["BBBB_CURRENT_AMMO"] = 20;
+			break;
+			
+		case item is MediumCumBubble:
+			flags["BBBB_CURRENT_AMMO"] += 5;
+			if (flags["BBBB_CURRENT_AMMO"] > 20) flags["BBBB_CURRENT_AMMO"] = 20;
+			break;
+			
+		case item is LargeCumBubble:
+			flags["BBBB_CURRENT_AMMO"] += 10;
+			if (flags["BBBB_CURRENT_AMMO"] > 20) flags["BBBB_CURRENT_AMMO"] = 20;
+			break;
+			
+		case item is HugeCumBubble:
+			flags["BBBB_CURRENT_AMMO"] += 20;
+			if (flags["BBBB_CURRENT_AMMO"] > 20) flags["BBBB_CURRENT_AMMO"] = 20;
+			break;
+	}
 }

--- a/includes/myrellion/steph.as
+++ b/includes/myrellion/steph.as
@@ -141,7 +141,7 @@ public function stephWorkPornstar():void
 	
 	output("\n\nSteph chuckles. <i>“I know, right? Never thought I’d do something like that, but ever since I did that exp... expos... uh, episode-thing on New Texas, I’ve just felt hornier and hornier... I used to feel bad about all the cute little aliens I’ve been documenting trying to fuck me, but now... I dunno! It’s exciting!”</i>");
 	
-	output("\n\nHer prior melancholy fades away in the blink of an eye, replaced by bubbly bimbo as she hugs her arms around herself in sudden excitement. <i>“With an X-net I’d, like, be able to do whatever I want with whatever I wanted! I mean, what director’s gonna turn away something like THAT?”</i> she cheers, pointing to her video self being bukakked by several small");
+	output("\n\nHer prior melancholy fades away in the blink of an eye, replaced by bubbly bimbo as she hugs her arms around herself in sudden excitement. <i>“With an X-net I’d, like, be able to do whatever I want with whatever I wanted! I mean, what director’s gonna turn away something like THAT?”</i> she cheers, pointing to her video self being bukkaked by several small");
 	if (!CodexManager.entryViewed("Raskvel")) output(", scaly");
 	else output(" raskvel");
 	output(" males. The Steph in front of you giggles as a particularly virile male busts his nut all over her digital face; another tears open the front of her shirt to ram his reptilian cock up between her still fairly mundane breasts, much smaller than the bovine rack she’s sporting now.");

--- a/includes/tavros/tamaniCorpShop.as
+++ b/includes/tavros/tamaniCorpShop.as
@@ -3,6 +3,7 @@ import classes.Items.Apparel.AssManBoxers;
 import classes.Items.Apparel.BackdoorBoiSlutwear;
 import classes.Items.Apparel.CumflationControlBoyshorts;
 import classes.Items.Apparel.SlutSealThong;
+import classes.Items.Guns.BubbleBuddyBukkakeBlaster;
 /*
 	LERRIS_TALKED_BACKROOM
 		0/undefined -- not even attempted the talk scene
@@ -122,6 +123,7 @@ public function lerrisProducts():void
 	chars["LERRIS"].inventory.push(new Lactaid());
 	chars["LERRIS"].inventory.push(new LactaidMilkTank());
 	chars["LERRIS"].inventory.push(new LactaidOverdrive());
+	if (flags["BBBB_CURRENT_AMMO"] == undefined) chars["LERRIS"].inventory.push(new BubbleBuddyBukkakeBlaster());
 	// Unlocks
 	if(pc.level >= 2) chars["LERRIS"].inventory.push(new NukiNutbutter());
 	if(pc.level >= 3) 
@@ -1199,3 +1201,4 @@ public function lerrisDrinkDatTittymilks():void
 	clearMenu();
 	addButton(0, "Next", mainGameMenu);
 }
+


### PR DESCRIPTION
Adds the Bubble Buddy Bukkake Blaster, a weapon that you load in cum bubbles (automatically during combat) to then fire the spunk at your enemies. Includes functions for managing the associated "ammo" requirements.

Available from the Tamanicorp shop for 25,000 credits, (effectively) comes with a Bubble Buddy, does 6 tease damage, and has the bonus hit rate flag, so it's a bit worse than the heavy slut ray. Since players need a lot of jizz to use it with any sort of consistency (small cum bubble gives 2 shots, medium 5, large 10, and huge 20) I felt that was a balanced price.

