### PR TITLE
do not change a truly demonic tailcock into a mere shodow of one.

### DIFF
--- a/classes/Items/Transformatives/Lucifier.as
+++ b/classes/Items/Transformatives/Lucifier.as
@@ -282,6 +282,7 @@ package classes.Items.Transformatives
 						if(target.tailGenitalColor != newTailColor) output(" and its coloration changes from [pc.tailGenitalColor] to " + newTailColor);
 						output(", giving it a very alien and demonic feel. When the change completes itself, you find that <b>you now have a demon-like cock tail!</b>");
 						
+						target.tailType = GLOBAL.TYPE_DEMONIC;
 						target.tailGenitalArg = GLOBAL.TYPE_DEMONIC;
 						target.clearTailFlags();
 						target.addTailFlag(GLOBAL.FLAG_PREHENSILE);

--- a/classes/Items/Transformatives/Lucifier.as
+++ b/classes/Items/Transformatives/Lucifier.as
@@ -108,7 +108,7 @@ package classes.Items.Transformatives
 			if(target.skinType == GLOBAL.SKIN_TYPE_SKIN && !InCollection(target.skinTone, demonSkinColor))
 				TFList.push(6);
 			// *Grow demon tail
-			if(!target.hasTail(GLOBAL.TYPE_DEMONIC))
+			if(!target.hasTail(GLOBAL.TYPE_DEMONIC) && !target.hasTailCock(GLOBAL.TYPE_DEMONIC))
 				TFList.push(7);
 			// *Increase libido towards 100 (+4 below 50 per dose, +2 above)
 			if(target.libido() < 100)
@@ -282,7 +282,6 @@ package classes.Items.Transformatives
 						if(target.tailGenitalColor != newTailColor) output(" and its coloration changes from [pc.tailGenitalColor] to " + newTailColor);
 						output(", giving it a very alien and demonic feel. When the change completes itself, you find that <b>you now have a demon-like cock tail!</b>");
 						
-						target.tailType = GLOBAL.TYPE_DEMONIC;
 						target.tailGenitalArg = GLOBAL.TYPE_DEMONIC;
 						target.clearTailFlags();
 						target.addTailFlag(GLOBAL.FLAG_PREHENSILE);


### PR DESCRIPTION
I believe there is a bug in demonic transformation right now.  
If PC was lucky and got a 1/5 chance of a truly demonic tailcock transformation, they can still loose it the next time they use Lucifier transformation since the tail transformation is pushed each time there is a nonfur tail of non demonic type [see here](https://github.com/OXOIndustries/TiTS-Public/blob/master/classes/Items/Transformatives/Lucifier.as#L111) but the code section which handles the truly demonic tailcock only sets tailcock genitalia to be demonic but leaves the tail type unchanged.  
